### PR TITLE
ci: allow coverage report to fail without blocking workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,8 @@ jobs:
     name: Coverage Report
     needs: [unit-and-slice, integration-test]
     runs-on: ubuntu-latest
+    # 템플릿 프로젝트이므로 커버리지 실패가 워크플로우를 차단하지 않도록 설정
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `coverage-report` 잡에 `continue-on-error: true` 추가
- 템플릿 프로젝트이므로 커버리지 실패가 워크플로우를 차단하지 않도록 설정

## Motivation
템플릿 프로젝트 특성상 실제 비즈니스 코드가 없어 커버리지 리포트가 실패할 수 있다.
리포트 생성은 계속 시도하되, 실패해도 전체 CI를 통과시킨다.

## Changes
- `.github/workflows/test.yml`: `coverage-report` 잡에 `continue-on-error: true` 추가

## Test plan
- [ ] CI 워크플로우가 coverage-report 실패와 무관하게 통과하는지 확인