### PR TITLE
docs: localize README to Korean and add missing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,344 @@
 # java-spring-template
 
-Spring Boot 4 + Hexagonal Architecture boilerplate template.
+**Spring Boot 4 + Hexagonal Architecture 범용 보일러플레이트**
 
-## Tech Stack
+Java 25, Virtual Threads, PostgreSQL 18 기반의 프로덕션 레디 템플릿.
+헥사고날 아키텍처(Ports & Adapters), CQRS, ArchUnit 기반 아키텍처 테스트를 내장합니다.
 
-| Component | Version |
-|-----------|---------|
+---
+
+## 목차
+
+1. [기술 스택](#기술-스택)
+2. [모듈 구조](#모듈-구조)
+3. [아키텍처](#아키텍처)
+4. [빠른 시작](#빠른-시작)
+5. [패키지 컨벤션](#패키지-컨벤션)
+6. [새 도메인 추가 가이드](#새-도메인-추가-가이드)
+7. [에러 처리](#에러-처리)
+8. [관측성](#관측성)
+9. [API 문서화](#api-문서화)
+10. [환경 설정](#환경-설정)
+11. [컨테이너화](#컨테이너화)
+12. [코드 품질 도구](#코드-품질-도구)
+
+---
+
+## 기술 스택
+
+| 구성 요소 | 버전 |
+|----------|------|
 | Java | 25 |
 | Spring Boot | 4.0.3 |
 | Gradle | 9.3.1 (Kotlin DSL) |
 | PostgreSQL | 18 |
 | Flyway | 12.0.1 |
-| Virtual Threads | Enabled |
+| Virtual Threads | 활성화 |
 
-## Module Structure
+---
 
+## 모듈 구조
+
+8개 모듈이 `template/` 하위에 플랫 구조로 배치됩니다.
+
+| 모듈 | 역할 | Spring | JPA |
+|------|------|--------|-----|
+| `template-domain` | 순수 도메인 모델 | ✗ | ✗ |
+| `template-application` | Port 인터페이스 + UseCase 구현체 | ✗ | ✗ |
+| `template-application-autoconfiguration` | UseCase Bean 등록 | ✓ | ✗ |
+| `template-adapter-input-api` | REST Controller + Security | ✓ | ✗ |
+| `template-adapter-input-ws` | WebSocket | ✓ | ✗ |
+| `template-adapter-output-persist` | JPA + Flyway | ✓ | ✓ |
+| `template-adapter-output-cache` | Cache | ✓ | ✗ |
+| `template-boot-api` | Spring Boot 앱 (port 8080) | ✓ | ✗ |
+
+### 모듈 의존성
+
+```mermaid
+graph TD
+    BOOT[template-boot-api]
+    AUTO[template-application-autoconfiguration]
+    API[template-adapter-input-api]
+    WS[template-adapter-input-ws]
+    PERSIST[template-adapter-output-persist]
+    CACHE[template-adapter-output-cache]
+    APP[template-application]
+    DOMAIN[template-domain]
+
+    BOOT --> AUTO
+    BOOT --> API
+    BOOT --> WS
+    BOOT --> PERSIST
+    BOOT --> CACHE
+    API --> APP
+    WS --> APP
+    PERSIST --> APP
+    CACHE --> APP
+    AUTO --> APP
+    APP --> DOMAIN
 ```
-template/
-  template-boot-api/                       # Port 8080 - Main API
-  template-domain/                         # Pure domain (NO Spring, NO JPA)
-  template-application/                    # Ports + UseCases (NO Spring)
-  template-application-autoconfiguration/  # UseCase Bean registration
-  template-adapter-input-api/              # REST + Security
-  template-adapter-input-ws/              # WebSocket
-  template-adapter-output-persist/         # JPA + Flyway
-  template-adapter-output-cache/           # Cache
+
+> adapter ↔ adapter 상호 의존 및 역방향 의존은 전면 금지입니다. ([ADR-0001](docs/decisions/0001-hexagonal-architecture-and-cqrs.md), [ADR-0002](docs/decisions/0002-flat-module-structure.md))
+
+---
+
+## 아키텍처
+
+헥사고날 아키텍처(Ports & Adapters) + CQRS 경계 분리를 채택합니다.
+
+```mermaid
+graph LR
+    subgraph Inbound Adapters
+        A1[REST API\ntemplate-adapter-input-api]
+        A2[WebSocket\ntemplate-adapter-input-ws]
+    end
+
+    subgraph Application Core
+        P1[Inbound Port\n UseCase / Query]
+        SVC[Service 구현체]
+        P2[Outbound Port\n Command / Query]
+    end
+
+    subgraph Outbound Adapters
+        O1[JPA / Flyway\ntemplate-adapter-output-persist]
+        O2[Cache\ntemplate-adapter-output-cache]
+    end
+
+    A1 -->|implements| P1
+    A2 -->|implements| P1
+    P1 --> SVC
+    SVC --> P2
+    P2 -->|implements| O1
+    P2 -->|implements| O2
 ```
 
-## Architecture
+### ArchUnit 강제 규칙
 
-Hexagonal Architecture (Ports & Adapters):
+| 규칙 | 내용 |
+|------|------|
+| domain 순수성 | `template-domain`에 Spring/JPA 의존 금지 |
+| application 순수성 | `template-application`에 Spring 의존 금지 |
+| Outbound Port | `..port.output..*`는 반드시 interface |
+| CQRS 경계 | Query Service → Command Outbound Port 의존 금지 |
 
-```
-Inbound Adapters       Application Core       Outbound Adapters
-(input-api)    ──>    (application)    ──>   (output-persist)
-(input-ws)            (domain)               (output-cache)
-```
+> 상세: [ADR-0003](docs/decisions/0003-package-structure-and-naming.md), [ADR-0004](docs/decisions/0004-architecture-testing-strategy.md)
 
-### Dependency Rules (enforced by ArchUnit)
+---
 
-- `template-domain`: NO Spring, NO JPA dependencies
-- `template-application`: NO Spring dependencies
-- Outbound ports must be interfaces
-- Query services cannot depend on Command ports
+## 빠른 시작
 
-## Quick Start
+### Prerequisites
+
+- Java 25
+- Docker (Testcontainers 기반 통합 테스트용)
+
+### 명령어
 
 ```bash
-# Build
+# 포맷 수정 (코드 작성 후 필수)
+./gradlew spotlessApply
+
+# 전체 빌드
 ./gradlew build
 
-# Run architecture tests
+# 아키텍처 테스트
 ./gradlew :template-domain:test :template-application:test
 
-# Code quality
-./gradlew spotlessCheck checkstyleMain
+# 전체 테스트
+./gradlew test
 
-# Run API server
+# API 서버 실행 (local 프로파일)
 ./gradlew :template-boot-api:bootRun
 ```
 
-## Package Convention
+---
 
-Base package: `io.github.ppzxc.template`
+## 패키지 컨벤션
 
-| Layer | Package |
-|-------|---------|
+베이스 패키지: `io.github.ppzxc.template`
+
+| 레이어 | 패키지 |
+|--------|--------|
 | Domain | `io.github.ppzxc.template.domain` |
-| Application | `io.github.ppzxc.template.application` |
+| Application UseCase | `io.github.ppzxc.template.application` |
+| Inbound Command Port | `io.github.ppzxc.template.application.port.input.command` |
+| Inbound Query Port | `io.github.ppzxc.template.application.port.input.query` |
+| Outbound Command Port | `io.github.ppzxc.template.application.port.output.command` |
+| Outbound Query Port | `io.github.ppzxc.template.application.port.output.query` |
 | API Adapter | `io.github.ppzxc.template.adapter.input.api` |
 | WS Adapter | `io.github.ppzxc.template.adapter.input.ws` |
 | Persist Adapter | `io.github.ppzxc.template.adapter.output.persist` |
 | Cache Adapter | `io.github.ppzxc.template.adapter.output.cache` |
 
-## Adding a New Domain
+### 네이밍 규칙
 
-1. Add domain model to `template-domain`
-2. Add port interfaces to `template-application/port/`
-3. Add UseCase interfaces and implementations to `template-application/`
-4. Register UseCase beans in `ApplicationAutoConfiguration`
-5. Add JPA entities and repositories to `template-adapter-output-persist`
-6. Add controllers to `template-adapter-input-api`
-7. Add Flyway migration to `template-adapter-output-persist/src/main/resources/db/migration/`
+| 타입 | 패턴 | 예시 |
+|------|------|------|
+| Inbound Command Port | `*UseCase` interface | `CreateOrderUseCase` |
+| Inbound Query Port | `*Query` interface | `FindOrderQuery` |
+| Outbound Port | `*Port` interface | `SaveOrderPort` |
+| UseCase 구현체 | `*Service` | `CreateOrderService` |
+| Controller | `*Controller` | `OrderController` |
+| JPA Entity | `*JpaEntity` | `OrderJpaEntity` |
+
+> 상세: [`.claude/rules/coding-style.md`](.claude/rules/coding-style.md)
+
+---
+
+## 새 도메인 추가 가이드
+
+1. `template-domain`에 도메인 모델 추가
+2. `template-application/port/`에 Port 인터페이스 추가
+3. `template-application/`에 UseCase 인터페이스 및 Service 구현체 추가
+4. `ApplicationAutoConfiguration`에 UseCase Bean 등록
+5. `template-adapter-output-persist`에 JPA Entity, Repository, Adapter 추가
+6. `template-adapter-input-api`에 Controller 추가
+7. `template-adapter-output-persist/src/main/resources/db/migration/`에 Flyway 마이그레이션 추가
+
+---
+
+## 에러 처리
+
+RFC 9457 `ProblemDetail` + 커스텀 `ErrorCode` enum을 사용합니다.
+
+```json
+{
+  "type": "https://example.com/errors/not-found",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "주문 ID 123을 찾을 수 없습니다.",
+  "instance": "/api/v1/orders/123",
+  "errorCode": "NOT_FOUND"
+}
+```
+
+- `ErrorCode` enum 위치: `io.github.ppzxc.template.domain` (template-domain 모듈)
+- 예외 변환 위치: `GlobalExceptionHandler` (`@RestControllerAdvice`, template-adapter-input-api)
+- domain/application 레이어는 순수 Java 예외만 사용
+
+> 상세: [`.claude/rules/error-handling.md`](.claude/rules/error-handling.md), [ADR-0007](docs/decisions/0007-error-handling-strategy.md)
+
+---
+
+## 관측성
+
+### 구조화 로깅
+
+Spring Boot 4 네이티브 구조화 로깅(Logstash 포맷)을 사용합니다.
+
+```java
+// 올바른 사용법 (SLF4J Fluent API)
+logger.atInfo()
+    .addKeyValue("orderId", orderId)
+    .log("주문 생성 완료");
+```
+
+### Actuator 엔드포인트
+
+| 엔드포인트 | 접근 URL |
+|-----------|---------|
+| 헬스 체크 | `GET /actuator/health` |
+| 메트릭 | `GET /actuator/metrics` |
+| 서비스 정보 | `GET /actuator/info` |
+
+### OpenTelemetry
+
+환경변수 `OTLP_ENDPOINT`로 수집 백엔드를 설정합니다. 미설정 시 OTel 전송을 비활성화합니다.
+
+> 상세: [`.claude/rules/observability.md`](.claude/rules/observability.md), [ADR-0008](docs/decisions/0008-observability-strategy.md)
+
+---
+
+## API 문서화
+
+### REST API (springdoc-openapi + Redoc)
+
+| URL | 설명 |
+|-----|------|
+| `/redoc.html` | Redoc UI (권장) |
+| `/v3/api-docs` | OpenAPI JSON |
+
+Swagger UI는 비활성화되어 있습니다. Redoc으로 통일합니다.
+
+### WebSocket (Springwolf + AsyncAPI)
+
+| URL | 설명 |
+|-----|------|
+| `/springwolf/asyncapi-ui.html` | AsyncAPI UI |
+
+> 상세: [`.claude/rules/api-documentation.md`](.claude/rules/api-documentation.md), [ADR-0009](docs/decisions/0009-api-documentation-strategy.md)
+
+---
+
+## 환경 설정
+
+### 프로파일 구조
+
+| 파일 | 용도 |
+|------|------|
+| `application.yml` | 공통 설정 + 환경변수 플레이스홀더 |
+| `application-local.yml` | 로컬 개발 (직접 DB 연결) |
+| `application-test.yml` | 테스트 (Testcontainers 연동) |
+| `application-prod.yml` | 프로덕션 (환경변수 중심, 기본값 없음) |
+
+### 주요 환경변수
+
+| 변수 | 설명 | 기본값 |
+|------|------|--------|
+| `SPRING_PROFILES_ACTIVE` | 활성 프로파일 | `local` |
+| `DB_URL` | PostgreSQL JDBC URL | `jdbc:postgresql://localhost:5432/template` |
+| `DB_USERNAME` | DB 사용자명 | `template` |
+| `DB_PASSWORD` | DB 패스워드 | **(필수, 기본값 없음)** |
+| `OTLP_ENDPOINT` | OTel 수집 엔드포인트 | (선택) |
+
+> 비밀(패스워드, 토큰)은 반드시 환경변수로 주입합니다. yml 파일에 평문 작성 금지.
+> 상세: [`.claude/rules/configuration.md`](.claude/rules/configuration.md), [ADR-0011](docs/decisions/0011-configuration-strategy.md)
+
+---
+
+## 컨테이너화
+
+### 이미지 빌드 (권장)
+
+```bash
+# Buildpacks 방식 (Dockerfile 불필요)
+./gradlew bootBuildImage
+```
+
+### docker-compose
+
+```bash
+# .env 파일에 DB_PASSWORD 설정 후 실행
+docker compose up -d
+```
+
+> 상세: [`.claude/rules/containerization.md`](.claude/rules/containerization.md), [ADR-0010](docs/decisions/0010-containerization-strategy.md)
+
+---
+
+## 코드 품질 도구
+
+| 도구 | 실행 시점 | 역할 |
+|------|----------|------|
+| Spotless (Google Java Format) | 코드 작성 후 | 포맷 자동 수정 |
+| Checkstyle | pre-commit / CI | 네이밍·금지 패턴 검사 |
+| ErrorProne + NullAway | 컴파일 시 | 버그 패턴·Null 안전성 |
+| ArchUnit | 테스트 시 | 아키텍처 규칙 강제 |
+| OpenRewrite | pre-push / CI | 코드 현대화 제안 |
+| Lefthook | Git Hook | 로컬 품질 게이트 |
+| JaCoCo | CI | 커버리지 집계 |
+
+```bash
+# 포맷 수정
+./gradlew spotlessApply
+
+# 네이밍/구조 검사
+./gradlew checkstyleMain
+
+# 코드 현대화 미리보기
+./gradlew rewriteDryRun
+```
+
+Lefthook 설치 후 `./gradlew lefthookInstall`로 Git Hook을 등록합니다.
+
+> 상세: [`.claude/rules/ci-tools.md`](.claude/rules/ci-tools.md), [ADR-0005](docs/decisions/0005-code-quality-toolchain.md), [ADR-0006](docs/decisions/0006-ci-pipeline-strategy.md)


### PR DESCRIPTION
## Summary
- README.md 전면 한글화 (영문 → 한글)
- Mermaid 다이어그램 2개 추가 (모듈 의존성, 헥사고날 아키텍처)
- ADR-0007~0011 내용 반영한 신규 섹션 7개 추가

## Motivation
기존 README는 영문으로 작성되어 있었으며, ADR-0001~0006 범위만 다루고 있었다. 프로젝트 규칙 파일과 ADR은 이미 한글로 작성되어 있어 README와 일관성이 없었다. 또한 에러 처리, 관측성, API 문서화, 환경 설정, 컨테이너화 등 ADR-0007~0011에서 결정된 전략이 README에 전혀 반영되지 않았다.

## Changes
- 전체 섹션 한글화 (기술 스택, 모듈 구조, 아키텍처, 빠른 시작, 패키지 컨벤션, 새 도메인 추가 가이드)
- Mermaid `graph TD` 모듈 의존성 다이어그램 추가
- Mermaid `graph LR` 헥사고날 아키텍처 다이어그램 추가
- 신규 섹션 추가: 에러 처리, 관측성, API 문서화, 환경 설정, 컨테이너화, 코드 품질 도구
- 각 섹션에서 관련 ADR 및 `.claude/rules/` 파일 링크 연결
- 목차(ToC) 추가

## Test plan
- [ ] Mermaid 다이어그램 GitHub에서 렌더링 확인
- [ ] 내부 링크 (ADR, rules 파일) 유효성 확인
- [ ] 목차 앵커 링크 동작 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.