### PR TITLE
fix(arch): exclude testFixtures from DomainArchitectureTest ArchUnit scan

### DIFF
--- a/template/template-domain/src/test/java/io/github/ppzxc/template/domain/architecture/DomainArchitectureTest.java
+++ b/template/template-domain/src/test/java/io/github/ppzxc/template/domain/architecture/DomainArchitectureTest.java
@@ -7,6 +7,7 @@ import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+import java.util.regex.Pattern;
 
 @AnalyzeClasses(
     packages = "io.github.ppzxc.template.domain",
@@ -17,9 +18,12 @@ import com.tngtech.archunit.lang.ArchRule;
 class DomainArchitectureTest {
 
   static final class DoNotIncludeTestFixtures implements ImportOption {
+    // Matches both Gradle directory (testFixtures) and JAR artifact (test-fixtures)
+    private static final Pattern PATTERN = Pattern.compile(".*(testFixtures|test-fixtures).*");
+
     @Override
     public boolean includes(Location location) {
-      return !location.contains("testFixtures");
+      return !location.matches(PATTERN);
     }
   }
 


### PR DESCRIPTION
## Summary

- `DomainArchitectureTest`에 `DoNotIncludeTestFixtures` 커스텀 `ImportOption` 추가
- `ImportOption.DoNotIncludeTests`는 `/test/` 경로만 제외하므로 `testFixtures` 소스셋(빌드 경로: `build/classes/java/testFixtures/`)을 걸러내지 못함
- `TodoFixtures.java`가 FixtureMonkey 의존성 위반으로 탐지되어 PR #32의 ArchUnit 및 PIT 테스트가 실패하던 문제 해결

## Test plan
- [ ] `:template-domain:test` 통과 확인 (DomainArchitectureTest 포함)
- [ ] PR #32 rebase 후 CI 통과 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.