### PR TITLE
build(deps): bump net.ltgt.errorprone from 4.2.0 to 5.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,7 @@ configureByLabel("java") {
   }
 
   tasks.withType<JavaCompile>().configureEach {
-    options.errorprone.isEnabled.set(true)
+    options.errorprone.enabled.set(true)
     options.errorprone.disableWarningsInGeneratedCode.set(true)
     options.errorprone {
       option("NullAway:AnnotatedPackages", "io.github.ppzxc.template")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ org-openrewrite-rewrite = "7.29.0"
 com-fizzpod-lefthook = "0.4.0"
 io-spring-dependency-management = "1.1.7"
 com-linecorp-build-recipe-plugin = "1.1.1"
-net-ltgt-errorprone = "4.2.0"
+net-ltgt-errorprone = "5.1.0"
 com-google-protobuf-plugin = "0.9.6"
 
 # tools


### PR DESCRIPTION
## Summary

- `net.ltgt.errorprone` Gradle 플러그인 4.2.0 → 5.1.0 버전 업
- v5.0에서 Kotlin DSL 프로퍼티명 변경: `isEnabled` → `enabled` (breaking change)
- `build.gradle.kts:110` 수정: `options.errorprone.isEnabled.set(true)` → `options.errorprone.enabled.set(true)`

Closes #35

## Test plan
- [ ] `./gradlew compileJava` 성공 확인
- [ ] ErrorProne + NullAway 정상 동작 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.