### PR TITLE
refactor: apply review items from issue #39

### DIFF
--- a/docs/decisions/0020-database-migration-strategy.md
+++ b/docs/decisions/0020-database-migration-strategy.md
@@ -28,6 +28,12 @@ decision-makers: ppzxc
 
 ### Consequences
 
-- 신규 스키마 변경은 반드시 Flyway 마이그레이션 스크립트로 추가
-- `spring.sql.init.*` 설정 제거
+Good, because:
+- SQL 마이그레이션 스크립트로 스키마 버전 관리 가능
+- Spring Boot 네이티브 통합으로 별도 설정 불필요
+- jOOQ DDLDatabase codegen과 자연스럽게 조합됨
 - Testcontainers 통합 테스트에서 Flyway가 자동 실행됨
+
+Bad, because:
+- 신규 스키마 변경 시 반드시 Flyway 마이그레이션 스크립트 추가 필요 (직접 DDL 편집 불가)
+- 기존 `spring.sql.init.*` 설정 제거 및 `schema.sql` 마이그레이션 작업 필요

--- a/template/template-adapter-input-api/src/main/java/io/github/ppzxc/template/adapter/input/api/GlobalExceptionHandler.java
+++ b/template/template-adapter-input-api/src/main/java/io/github/ppzxc/template/adapter/input/api/GlobalExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -93,9 +92,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       @NonNull HttpStatusCode status,
       @NonNull WebRequest request) {
     List<FieldViolationDto> violations =
-        ex.getBindingResult().getAllErrors().stream()
-            .filter(error -> error instanceof FieldError)
-            .map(error -> (FieldError) error)
+        ex.getBindingResult().getFieldErrors().stream()
             .map(
                 fieldError ->
                     new FieldViolationDto(

--- a/template/template-boot-api/src/test/java/io/github/ppzxc/template/TodoCrudIT.java
+++ b/template/template-boot-api/src/test/java/io/github/ppzxc/template/TodoCrudIT.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,7 +57,8 @@ class TodoCrudIT {
             .andExpect(jsonPath("$.completed").value(false))
             .andReturn();
 
-    String location = Objects.requireNonNull(result.getResponse().getHeader("Location"));
+    String location = result.getResponse().getHeader("Location");
+    assertThat(location).isNotNull();
     assertThat(location).startsWith("/todos/");
   }
 
@@ -73,7 +73,8 @@ class TodoCrudIT {
             .andExpect(status().isCreated())
             .andReturn();
 
-    String location = Objects.requireNonNull(createResult.getResponse().getHeader("Location"));
+    String location = createResult.getResponse().getHeader("Location");
+    assertThat(location).isNotNull();
 
     mockMvc
         .perform(get(location))
@@ -109,7 +110,8 @@ class TodoCrudIT {
             .andExpect(status().isCreated())
             .andReturn();
 
-    String location = Objects.requireNonNull(createResult.getResponse().getHeader("Location"));
+    String location = createResult.getResponse().getHeader("Location");
+    assertThat(location).isNotNull();
 
     mockMvc
         .perform(
@@ -132,7 +134,8 @@ class TodoCrudIT {
             .andExpect(status().isCreated())
             .andReturn();
 
-    String location = Objects.requireNonNull(createResult.getResponse().getHeader("Location"));
+    String location = createResult.getResponse().getHeader("Location");
+    assertThat(location).isNotNull();
 
     mockMvc.perform(delete(location)).andExpect(status().isNoContent());
 


### PR DESCRIPTION
## Summary

이슈 #39의 3가지 리뷰 항목 반영

- **GlobalExceptionHandler.java**: `getAllErrors().stream().filter(instanceof FieldError).map(cast)` → `getFieldErrors().stream()` 간결화
- **TodoCrudIT.java**: `Objects.requireNonNull()` → `assertThat(location).isNotNull()` (테스트 실패 메시지 명확화), 미사용 `Objects` import 제거
- **ADR-0020**: `Consequences` 섹션을 MADR 4.0 `Good, because` / `Bad, because` 형식으로 보완

Closes #39

## Test plan
- [ ] `:template-adapter-input-api:compileJava` 통과
- [ ] `:template-boot-api:test` 통과 (통합 테스트 포함)

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.