### PR TITLE
test: add coverage gate and missing tests for adapters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,12 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 7
 
+      - name: Verify coverage thresholds (domain & application)
+        run: >
+          ./gradlew
+          :boilerplate-domain:jacocoTestCoverageVerification
+          :boilerplate-application:jacocoTestCoverageVerification
+
       - name: Upload JaCoCo reports
         uses: actions/upload-artifact@v7
         if: always()
@@ -152,8 +158,6 @@ jobs:
     name: Coverage Report
     needs: [unit-and-slice, integration-test]
     runs-on: ubuntu-latest
-    # 템플릿 프로젝트이므로 커버리지 실패가 워크플로우를 차단하지 않도록 설정
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 

--- a/boilerplate/boilerplate-adapter-output-cache/src/test/java/io/github/ppzxc/boilerplate/adapter/output/cache/CaffeineTodoCacheAdapterTest.java
+++ b/boilerplate/boilerplate-adapter-output-cache/src/test/java/io/github/ppzxc/boilerplate/adapter/output/cache/CaffeineTodoCacheAdapterTest.java
@@ -1,0 +1,99 @@
+package io.github.ppzxc.boilerplate.adapter.output.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.github.ppzxc.boilerplate.domain.Todo;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+
+class CaffeineTodoCacheAdapterTest {
+
+  private CaffeineTodoCacheAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    CaffeineCacheManager manager = new CaffeineCacheManager("todos");
+    manager.setCaffeine(Caffeine.newBuilder().maximumSize(100));
+    manager.setAllowNullValues(false);
+    adapter = new CaffeineTodoCacheAdapter(manager);
+  }
+
+  @Test
+  void get_returnEmpty_whenCacheMiss() {
+    Optional<Todo> result = adapter.get(999L);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void put_andGet_returnsCachedTodo() {
+    Todo todo = Todo.reconstitute(1L, "cached todo", false, now(), now());
+
+    adapter.put(todo);
+    Optional<Todo> result = adapter.get(1L);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getId()).isEqualTo(1L);
+    assertThat(result.get().getTitle()).isEqualTo("cached todo");
+  }
+
+  @Test
+  void evict_removesEntryFromCache() {
+    Todo todo = Todo.reconstitute(2L, "to be evicted", false, now(), now());
+    adapter.put(todo);
+    assertThat(adapter.get(2L)).isPresent();
+
+    adapter.evict(2L);
+
+    assertThat(adapter.get(2L)).isEmpty();
+  }
+
+  @Test
+  void put_doesNothing_whenTodoIdIsNull() {
+    Todo todoWithoutId = Todo.create("no id yet");
+
+    adapter.put(todoWithoutId);
+
+    // id가 null이면 캐시에 저장하지 않으므로, 어떤 키로도 조회 불가
+    assertThat(adapter.get(0L)).isEmpty();
+  }
+
+  @Test
+  void get_returnEmpty_whenCacheNameNotFound() {
+    CaffeineCacheManager emptyManager = new CaffeineCacheManager();
+    emptyManager.setCaffeine(Caffeine.newBuilder().maximumSize(100));
+    CaffeineTodoCacheAdapter adapterWithoutCache = new CaffeineTodoCacheAdapter(emptyManager);
+
+    Optional<Todo> result = adapterWithoutCache.get(1L);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void put_doesNothing_whenCacheNameNotFound() {
+    CaffeineCacheManager emptyManager = new CaffeineCacheManager();
+    emptyManager.setCaffeine(Caffeine.newBuilder().maximumSize(100));
+    CaffeineTodoCacheAdapter adapterWithoutCache = new CaffeineTodoCacheAdapter(emptyManager);
+    Todo todo = Todo.reconstitute(1L, "title", false, now(), now());
+
+    adapterWithoutCache.put(todo);
+    // should not throw
+  }
+
+  @Test
+  void evict_doesNothing_whenCacheNameNotFound() {
+    CaffeineCacheManager emptyManager = new CaffeineCacheManager();
+    emptyManager.setCaffeine(Caffeine.newBuilder().maximumSize(100));
+    CaffeineTodoCacheAdapter adapterWithoutCache = new CaffeineTodoCacheAdapter(emptyManager);
+
+    adapterWithoutCache.evict(1L);
+    // should not throw
+  }
+
+  private static java.time.LocalDateTime now() {
+    return java.time.LocalDateTime.now(java.time.ZoneId.systemDefault());
+  }
+}

--- a/boilerplate/boilerplate-adapter-output-external/src/test/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClientTest.java
+++ b/boilerplate/boilerplate-adapter-output-external/src/test/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClientTest.java
@@ -1,0 +1,98 @@
+package io.github.ppzxc.boilerplate.adapter.output.external;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+class ExternalApiClientTest {
+
+  private ExternalApiClient client;
+  private CircuitBreakerRegistry circuitBreakerRegistry;
+  private RetryRegistry retryRegistry;
+  private RateLimiterRegistry rateLimiterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+    retryRegistry = RetryRegistry.ofDefaults();
+    rateLimiterRegistry = RateLimiterRegistry.ofDefaults();
+    client =
+        new ExternalApiClient(
+            RestClient.create(), circuitBreakerRegistry, retryRegistry, rateLimiterRegistry);
+  }
+
+  @Test
+  void fetchById_returnsEmpty_forSkeletonImplementation() {
+    Optional<String> result = client.fetchById("any-id");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void fetchById_usesCircuitBreaker_byComponentName() {
+    CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("externalApi");
+
+    assertThat(circuitBreaker).isNotNull();
+    assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+  }
+
+  @Test
+  void fetchById_circuitBreakerOpens_whenFailureThresholdExceeded() {
+    CircuitBreakerConfig config =
+        CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .minimumNumberOfCalls(2)
+            .failureRateThreshold(100f)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .build();
+    CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+    CircuitBreaker circuitBreaker = registry.circuitBreaker("externalApi");
+
+    // 실패를 시뮬레이션하여 CircuitBreaker 상태 변경
+    circuitBreaker.onError(0, java.util.concurrent.TimeUnit.NANOSECONDS, new RuntimeException());
+    circuitBreaker.onError(0, java.util.concurrent.TimeUnit.NANOSECONDS, new RuntimeException());
+
+    assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+  }
+
+  @Test
+  void fetchById_throwsCallNotPermitted_whenCircuitBreakerIsOpen() {
+    CircuitBreakerConfig config =
+        CircuitBreakerConfig.custom()
+            .slidingWindowSize(2)
+            .minimumNumberOfCalls(2)
+            .failureRateThreshold(100f)
+            .waitDurationInOpenState(Duration.ofSeconds(60))
+            .build();
+    CircuitBreakerRegistry openRegistry = CircuitBreakerRegistry.of(config);
+    openRegistry.circuitBreaker("externalApi").transitionToOpenState();
+
+    RetryConfig retryConfig = RetryConfig.custom().maxAttempts(1).build();
+    RetryRegistry noRetry = RetryRegistry.of(retryConfig);
+
+    ExternalApiClient clientWithOpenCircuit =
+        new ExternalApiClient(RestClient.create(), openRegistry, noRetry, rateLimiterRegistry);
+
+    assertThatThrownBy(() -> clientWithOpenCircuit.fetchById("id"))
+        .isInstanceOf(CallNotPermittedException.class);
+  }
+
+  @Test
+  void fetchById_retriesOnFailure_withRetryRegistry() {
+    // RetryRegistry가 기본 설정으로 최대 3회 재시도하는지 확인
+    RetryConfig defaultConfig = retryRegistry.retry("externalApi").getRetryConfig();
+    assertThat(defaultConfig.getMaxAttempts()).isGreaterThan(1);
+  }
+}

--- a/boilerplate/boilerplate-application/build.gradle.kts
+++ b/boilerplate/boilerplate-application/build.gradle.kts
@@ -1,6 +1,21 @@
 // boilerplate-application: Inbound Port + Outbound Port + UseCase 구현체 — Spring 의존 금지
 apply(plugin = rootProject.libs.plugins.pitest.get().pluginId)
 
+tasks.jacocoTestCoverageVerification {
+  violationRules {
+    rule {
+      limit {
+        counter = "LINE"
+        value = "COVEREDRATIO"
+        minimum = "0.80".toBigDecimal()
+      }
+    }
+  }
+  classDirectories.setFrom(
+    classDirectories.files.map { fileTree(it) { exclude("**/generated/**") } }
+  )
+}
+
 extensions.configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
   targetClasses.set(listOf("io.github.ppzxc.boilerplate.application.*"))
   targetTests.set(listOf("io.github.ppzxc.boilerplate.application.*"))

--- a/boilerplate/boilerplate-domain/build.gradle.kts
+++ b/boilerplate/boilerplate-domain/build.gradle.kts
@@ -1,6 +1,21 @@
 // boilerplate-domain: 순수 도메인 모델 — Spring/JPA 의존 금지
 apply(plugin = rootProject.libs.plugins.pitest.get().pluginId)
 
+tasks.jacocoTestCoverageVerification {
+  violationRules {
+    rule {
+      limit {
+        counter = "LINE"
+        value = "COVEREDRATIO"
+        minimum = "0.80".toBigDecimal()
+      }
+    }
+  }
+  classDirectories.setFrom(
+    classDirectories.files.map { fileTree(it) { exclude("**/generated/**") } }
+  )
+}
+
 extensions.configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
   targetClasses.set(listOf("io.github.ppzxc.boilerplate.domain.*"))
   targetTests.set(listOf("io.github.ppzxc.boilerplate.domain.*"))

--- a/boilerplate/boilerplate-domain/src/test/java/io/github/ppzxc/boilerplate/domain/TodoPropertyTest.java
+++ b/boilerplate/boilerplate-domain/src/test/java/io/github/ppzxc/boilerplate/domain/TodoPropertyTest.java
@@ -71,6 +71,54 @@ class TodoPropertyTest {
     assertThat(updated.getTitle()).isEqualTo(inner);
   }
 
+  /**
+   * 불변식 5: complete()는 멱등하다.
+   *
+   * <p>이미 완료된 Todo에 complete()를 한 번 더 호출해도 completed=true이다.
+   */
+  @Property
+  void complete_is_idempotent(@ForAll @AlphaChars @StringLength(min = 1, max = 50) String title) {
+    Todo todo = Todo.create(title);
+
+    boolean result = todo.complete().complete().isCompleted();
+
+    assertThat(result).isTrue();
+  }
+
+  /**
+   * 불변식 6: uncomplete()는 멱등하다.
+   *
+   * <p>이미 미완료인 Todo에 uncomplete()를 한 번 더 호출해도 completed=false이다.
+   */
+  @Property
+  void uncomplete_is_idempotent(@ForAll @AlphaChars @StringLength(min = 1, max = 50) String title) {
+    Todo todo = Todo.create(title);
+
+    boolean result = todo.uncomplete().uncomplete().isCompleted();
+
+    assertThat(result).isFalse();
+  }
+
+  /**
+   * 불변식 7: Todo의 상태 변환 메서드는 원본을 변경하지 않는다 (불변성).
+   *
+   * <p>complete(), uncomplete(), updateTitle() 호출 후 원본 Todo의 상태는 그대로여야 한다.
+   */
+  @Property
+  void state_transitions_do_not_mutate_original(
+      @ForAll @AlphaChars @StringLength(min = 1, max = 50) String title) {
+    Todo original = Todo.create(title);
+    String originalTitle = original.getTitle();
+    boolean originalCompleted = original.isCompleted();
+
+    original.complete();
+    original.uncomplete();
+    original.updateTitle("changed title");
+
+    assertThat(original.getTitle()).isEqualTo(originalTitle);
+    assertThat(original.isCompleted()).isEqualTo(originalCompleted);
+  }
+
   @Provide
   Arbitrary<String> blankStrings() {
     return Arbitraries.strings().withChars(' ', '\t', '\n', '\r').ofMinLength(1).ofMaxLength(20);


### PR DESCRIPTION
## Summary
- domain/application 모듈에 JaCoCo 80% 라인 커버리지 게이트 추가
- CI unit-and-slice job에 커버리지 검증 단계 추가 (`continue-on-error` 제거)
- `CaffeineTodoCacheAdapter` 단위 테스트 7개 추가
- `ExternalApiClient` 단위 테스트 5개 추가 (Resilience4j 동작 검증)
- jqwik 속성 테스트 3개 추가 (멱등성, 불변성 불변식)

## Motivation
보일러플레이트 브레인스토밍 결과 도출된 Phase 1 코드 품질 개선.
어댑터 모듈에 테스트가 전혀 없었고, 커버리지가 CI에서 강제되지 않았다.

## Changes
- `boilerplate-domain/build.gradle.kts`: `jacocoTestCoverageVerification` 80% 설정
- `boilerplate-application/build.gradle.kts`: `jacocoTestCoverageVerification` 80% 설정
- `.github/workflows/test.yml`: 커버리지 검증 step 추가, `continue-on-error` 제거
- `CaffeineTodoCacheAdapterTest.java`: get/put/evict 단위 테스트
- `ExternalApiClientTest.java`: CircuitBreaker/Retry 패턴 검증 테스트
- `TodoPropertyTest.java`: 멱등성(불변식 5,6) + 불변성(불변식 7) 추가

## Test plan
- [ ] `./gradlew :boilerplate-domain:jacocoTestCoverageVerification` 통과
- [ ] `./gradlew :boilerplate-application:jacocoTestCoverageVerification` 통과
- [ ] `./gradlew :boilerplate-adapter-output-cache:test` 통과 (7 tests)
- [ ] `./gradlew :boilerplate-adapter-output-external:test` 통과 (5 tests)