### PR TITLE
feat(phase3): CORS 명시화 및 HealthIndicator 헥사고날 원칙 적용

### DIFF
--- a/boilerplate/boilerplate-adapter-output-external/src/main/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClient.java
+++ b/boilerplate/boilerplate-adapter-output-external/src/main/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClient.java
@@ -1,5 +1,6 @@
 package io.github.ppzxc.boilerplate.adapter.output.external;
 
+import io.github.ppzxc.boilerplate.application.port.output.shared.CheckExternalServiceHealthPort;
 import io.github.ppzxc.boilerplate.application.port.output.shared.ExternalDataPort;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
@@ -17,7 +18,7 @@ import org.springframework.web.client.RestClient;
  * <p>CircuitBreaker + Retry + RateLimiter 패턴 예시. 실제 외부 API 연동 시 이 클래스를 참조하여 구현.
  */
 @SuppressWarnings("UnusedVariable")
-public class ExternalApiClient implements ExternalDataPort {
+public class ExternalApiClient implements ExternalDataPort, CheckExternalServiceHealthPort {
 
   private static final String COMPONENT_NAME = "externalApi";
 
@@ -51,5 +52,11 @@ public class ExternalApiClient implements ExternalDataPort {
     // 예: return Optional.ofNullable(
     //       restClient.get().uri("/resources/{id}", id).retrieve().body(String.class));
     return Optional.empty();
+  }
+
+  @Override
+  public boolean isHealthy() {
+    // CircuitBreaker 상태가 OPEN이면 외부 서비스 장애로 판단
+    return circuitBreaker.getState() != CircuitBreaker.State.OPEN;
   }
 }

--- a/boilerplate/boilerplate-adapter-output-external/src/main/java/io/github/ppzxc/boilerplate/autoconfigure/adapter/output/external/ExternalAdapterAutoConfiguration.java
+++ b/boilerplate/boilerplate-adapter-output-external/src/main/java/io/github/ppzxc/boilerplate/autoconfigure/adapter/output/external/ExternalAdapterAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.ppzxc.boilerplate.autoconfigure.adapter.output.external;
 
 import io.github.ppzxc.boilerplate.adapter.output.external.ExternalApiClient;
+import io.github.ppzxc.boilerplate.application.port.output.shared.CheckExternalServiceHealthPort;
 import io.github.ppzxc.boilerplate.application.port.output.shared.ExternalDataPort;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
@@ -52,6 +53,13 @@ public class ExternalAdapterAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   ExternalDataPort externalDataPort(ExternalApiClient externalApiClient) {
+    return externalApiClient;
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  CheckExternalServiceHealthPort checkExternalServiceHealthPort(
+      ExternalApiClient externalApiClient) {
     return externalApiClient;
   }
 }

--- a/boilerplate/boilerplate-application/src/main/java/io/github/ppzxc/boilerplate/application/port/output/shared/CheckExternalServiceHealthPort.java
+++ b/boilerplate/boilerplate-application/src/main/java/io/github/ppzxc/boilerplate/application/port/output/shared/CheckExternalServiceHealthPort.java
@@ -1,0 +1,8 @@
+package io.github.ppzxc.boilerplate.application.port.output.shared;
+
+/** 외부 서비스 연결 상태를 확인하는 Outbound Port. */
+public interface CheckExternalServiceHealthPort {
+
+  /** 외부 서비스가 정상인지 확인한다. */
+  boolean isHealthy();
+}

--- a/boilerplate/boilerplate-boot-api/build.gradle.kts
+++ b/boilerplate/boilerplate-boot-api/build.gradle.kts
@@ -2,6 +2,7 @@
 // spring 라벨이 spring-boot-starter, spring-boot-starter-test 처리
 // boot 라벨이 BootJar 활성화 처리
 dependencies {
+  implementation(project(":boilerplate-application"))
   implementation(project(":boilerplate-application-autoconfiguration"))
   implementation(project(":boilerplate-adapter-input-api"))
   implementation(project(":boilerplate-adapter-input-ws"))

--- a/boilerplate/boilerplate-boot-api/src/main/java/io/github/ppzxc/boilerplate/autoconfigure/BootApiAutoConfiguration.java
+++ b/boilerplate/boilerplate-boot-api/src/main/java/io/github/ppzxc/boilerplate/autoconfigure/BootApiAutoConfiguration.java
@@ -1,5 +1,6 @@
 package io.github.ppzxc.boilerplate.autoconfigure;
 
+import io.github.ppzxc.boilerplate.application.port.output.shared.CheckExternalServiceHealthPort;
 import io.github.ppzxc.boilerplate.health.ExternalServiceHealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -11,7 +12,8 @@ public class BootApiAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  ExternalServiceHealthIndicator externalServiceHealthIndicator() {
-    return new ExternalServiceHealthIndicator();
+  ExternalServiceHealthIndicator externalServiceHealthIndicator(
+      CheckExternalServiceHealthPort checkExternalServiceHealthPort) {
+    return new ExternalServiceHealthIndicator(checkExternalServiceHealthPort);
   }
 }

--- a/boilerplate/boilerplate-boot-api/src/main/java/io/github/ppzxc/boilerplate/health/ExternalServiceHealthIndicator.java
+++ b/boilerplate/boilerplate-boot-api/src/main/java/io/github/ppzxc/boilerplate/health/ExternalServiceHealthIndicator.java
@@ -1,24 +1,21 @@
 package io.github.ppzxc.boilerplate.health;
 
+import io.github.ppzxc.boilerplate.application.port.output.shared.CheckExternalServiceHealthPort;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 
-/** 외부 서비스 헬스체크 스켈레톤. 실제 외부 서비스 연결 확인 로직으로 교체하여 사용. */
+/** 외부 서비스 헬스체크. CheckExternalServiceHealthPort를 통해 헥사고날 경계를 준수한다. */
+@RequiredArgsConstructor
 public class ExternalServiceHealthIndicator implements HealthIndicator {
+
+  private final CheckExternalServiceHealthPort checkExternalServiceHealthPort;
 
   @Override
   public Health health() {
-    // 스켈레톤: 실제 외부 서비스 health check 로직으로 교체
-    // 예: HTTP ping, gRPC health check 등
-    boolean externalServiceUp = checkExternalService();
-    if (externalServiceUp) {
+    if (checkExternalServiceHealthPort.isHealthy()) {
       return Health.up().withDetail("externalService", "reachable").build();
     }
     return Health.down().withDetail("externalService", "unreachable").build();
-  }
-
-  private boolean checkExternalService() {
-    // TODO: 실제 외부 서비스 연결 확인 로직 구현
-    return true;
   }
 }

--- a/boilerplate/boilerplate-boot-api/src/main/resources/application-local.yml
+++ b/boilerplate/boilerplate-boot-api/src/main/resources/application-local.yml
@@ -9,3 +9,6 @@ spring:
     username: boilerplate
   jooq:
     sql-dialect: POSTGRES
+
+cors:
+  allowed-origins: http://localhost:3000

--- a/boilerplate/boilerplate-boot-api/src/main/resources/application-prod.yml
+++ b/boilerplate/boilerplate-boot-api/src/main/resources/application-prod.yml
@@ -4,3 +4,6 @@ management:
       show-details: when-authorized
       probes:
         enabled: true
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION
## Summary
- CORS allowed-origins를 프로파일별 yml에 명시 (local: localhost:3000, prod: 환경변수 필수)
- `CheckExternalServiceHealthPort` 인터페이스 추가 (application 레이어 shared port)
- `ExternalApiClient`가 `CheckExternalServiceHealthPort` 구현 (CircuitBreaker 상태 기반)
- `ExternalServiceHealthIndicator` TODO 제거 — 포트 경유로 헥사고날 원칙 준수

## Motivation
HealthIndicator(입력 어댑터)가 내부에 TODO 코드와 함께 외부 서비스 확인 로직을 직접 보유하여
헥사고날 아키텍처 경계를 위반하고 있었다. 출력 어댑터(ExternalApiClient)가 포트를 통해
상태를 제공하도록 리팩토링하여 레이어 경계를 복원했다.

## Changes
- `application/port/output/shared/CheckExternalServiceHealthPort.java` (신규)
- `ExternalApiClient`: `CheckExternalServiceHealthPort` 구현 추가, `isHealthy()` 메서드 (CircuitBreaker.State != OPEN)
- `ExternalAdapterAutoConfiguration`: `CheckExternalServiceHealthPort` Bean 등록
- `ExternalServiceHealthIndicator`: 포트 생성자 주입으로 변경, TODO 제거
- `BootApiAutoConfiguration`: `CheckExternalServiceHealthPort` 파라미터 추가
- `boilerplate-boot-api/build.gradle.kts`: application 모듈 의존성 추가 (포트 타입 참조)
- `application-local.yml`: `cors.allowed-origins: http://localhost:3000`
- `application-prod.yml`: `cors.allowed-origins: ${CORS_ALLOWED_ORIGINS}` (기본값 없음)

## Test plan
- [ ] `./gradlew compileJava` 통과
- [ ] `./gradlew :boilerplate-domain:test :boilerplate-application:test :boilerplate-adapter-input-api:test` 통과
- [ ] CircuitBreaker OPEN 상태 시 `isHealthy()` false 반환 확인