### PR TITLE
feat(phase4): DX 스크립트 및 Devcontainer 추가

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Spring Vibe Boilerplate",
+  "image": "mcr.microsoft.com/devcontainers/java:1-25-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-spring-boot-dashboard",
+        "vmware.vscode-spring-boot",
+        "vscjava.vscode-gradle",
+        "redhat.vscode-yaml",
+        "EditorConfig.EditorConfig"
+      ],
+      "settings": {
+        "java.jdt.ls.java.home": "/usr/local/sdkman/candidates/java/current",
+        "editor.formatOnSave": false,
+        "editor.tabSize": 2
+      }
+    }
+  },
+  "postCreateCommand": "./gradlew compileJava --no-daemon",
+  "forwardPorts": [8080],
+  "portsAttributes": {
+    "8080": {
+      "label": "API Server",
+      "onAutoForward": "notify"
+    }
+  }
+}

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# init-project.sh — 보일러플레이트를 새 프로젝트로 초기화한다.
+#
+# 사용법:
+#   ./scripts/init-project.sh <new-group-id> <new-artifact-name> [--dry-run]
+#
+# 예시:
+#   ./scripts/init-project.sh com.example myapp
+#   ./scripts/init-project.sh com.example myapp --dry-run
+#
+# 변경 내용:
+#   - 패키지명: io.github.ppzxc.boilerplate → <new-group-id>.<new-artifact-name>
+#   - 모듈명: boilerplate-* → <new-artifact-name>-*
+#   - 루트 프로젝트명: boilerplate → <new-artifact-name>
+#   - 디렉토리명: boilerplate/ → <new-artifact-name>/
+
+set -euo pipefail
+
+# ── 인자 파싱 ─────────────────────────────────────────────────────────────────
+
+usage() {
+  echo "Usage: $0 <new-group-id> <new-artifact-name> [--dry-run]" >&2
+  echo "  new-group-id:      e.g. com.example" >&2
+  echo "  new-artifact-name: e.g. myapp (alphanumeric and hyphens only)" >&2
+  exit 1
+}
+
+if [[ $# -lt 2 ]]; then usage; fi
+
+NEW_GROUP="$1"
+NEW_ARTIFACT="$2"
+DRY_RUN=false
+
+for arg in "${@:3}"; do
+  if [[ "$arg" == "--dry-run" ]]; then
+    DRY_RUN=true
+  fi
+done
+
+# ── 입력 검증 ─────────────────────────────────────────────────────────────────
+
+if [[ ! "$NEW_GROUP" =~ ^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$ ]]; then
+  echo "Error: new-group-id must be a valid reverse-domain identifier (e.g. com.example)" >&2
+  exit 1
+fi
+
+if [[ ! "$NEW_ARTIFACT" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  echo "Error: new-artifact-name must be lowercase alphanumeric with hyphens (e.g. myapp)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# ── Git dirty check ────────────────────────────────────────────────────────────
+
+cd "$PROJECT_ROOT"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: Working directory has uncommitted changes. Please commit or stash first." >&2
+  exit 1
+fi
+
+# ── 치환 값 계산 ──────────────────────────────────────────────────────────────
+
+OLD_GROUP="io.github.ppzxc.boilerplate"
+OLD_GROUP_PATH="io/github/ppzxc/boilerplate"
+OLD_ARTIFACT="boilerplate"
+
+NEW_GROUP_PATH="${NEW_GROUP//./\/}/${NEW_ARTIFACT}"
+NEW_PACKAGE="${NEW_GROUP}.${NEW_ARTIFACT}"
+
+echo "=== init-project ==="
+echo "  old package : ${OLD_GROUP}"
+echo "  new package : ${NEW_PACKAGE}"
+echo "  old artifact: ${OLD_ARTIFACT}"
+echo "  new artifact: ${NEW_ARTIFACT}"
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "  mode        : DRY-RUN (no changes will be made)"
+else
+  echo "  mode        : APPLY"
+fi
+echo ""
+
+# ── 헬퍼 함수 ────────────────────────────────────────────────────────────────
+
+run() {
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY-RUN] $*"
+  else
+    eval "$@"
+  fi
+}
+
+# 텍스트 파일 내용 치환 (macOS/Linux 모두 지원)
+replace_in_file() {
+  local file="$1"
+  local old="$2"
+  local new="$3"
+  if grep -qF "$old" "$file" 2>/dev/null; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "[DRY-RUN] sed: $file : '$old' → '$new'"
+    else
+      sed -i "s|${old}|${new}|g" "$file"
+    fi
+  fi
+}
+
+# ── 1단계: 텍스트 치환 (파일 내용) ──────────────────────────────────────────
+
+echo "--- Step 1: Replace text in files ---"
+
+# 대상 파일: *.java, *.kts, *.yml, *.yaml, *.md, *.properties, *.xml, *.toml
+mapfile -t TEXT_FILES < <(
+  find "$PROJECT_ROOT" \
+    -not -path "*/\.*" \
+    -not -path "*/build/*" \
+    -not -path "*/generated*" \
+    -not -path "*/.worktrees/*" \
+    -type f \
+    \( -name "*.java" -o -name "*.kts" -o -name "*.yml" -o -name "*.yaml" \
+       -o -name "*.md" -o -name "*.properties" -o -name "*.xml" -o -name "*.toml" \
+       -o -name "*.imports" -o -name "*.sh" \) 2>/dev/null
+)
+
+for file in "${TEXT_FILES[@]}"; do
+  # 패키지 경로 (디렉토리 구분자 포함)
+  replace_in_file "$file" "${OLD_GROUP_PATH}" "${NEW_GROUP_PATH}"
+  # 패키지명
+  replace_in_file "$file" "${OLD_GROUP}" "${NEW_PACKAGE}"
+  # 모듈명 (boilerplate- 접두사)
+  replace_in_file "$file" "${OLD_ARTIFACT}-" "${NEW_ARTIFACT}-"
+  # 프로젝트 루트명 단독
+  replace_in_file "$file" "\"${OLD_ARTIFACT}\"" "\"${NEW_ARTIFACT}\""
+  # application.yml의 app.name 등에서 단독 사용
+  replace_in_file "$file" ": ${OLD_ARTIFACT}" ": ${NEW_ARTIFACT}"
+  replace_in_file "$file" "=${OLD_ARTIFACT}" "=${NEW_ARTIFACT}"
+done
+
+# ── 2단계: Java 패키지 디렉토리 이름 변경 ────────────────────────────────────
+
+echo "--- Step 2: Rename Java package directories ---"
+
+OLD_JAVA_BASE="src/main/java/${OLD_GROUP_PATH}"
+NEW_JAVA_BASE="src/main/java/${NEW_GROUP_PATH}"
+
+OLD_TEST_BASE="src/test/java/${OLD_GROUP_PATH}"
+NEW_TEST_BASE="src/test/java/${NEW_GROUP_PATH}"
+
+OLD_FIXTURE_BASE="src/testFixtures/java/${OLD_GROUP_PATH}"
+NEW_FIXTURE_BASE="src/testFixtures/java/${NEW_GROUP_PATH}"
+
+# 각 모듈의 패키지 디렉토리를 재귀적으로 이동
+for module_dir in "$PROJECT_ROOT/${OLD_ARTIFACT}/"*/; do
+  for src_pair in \
+    "${OLD_JAVA_BASE}:${NEW_JAVA_BASE}" \
+    "${OLD_TEST_BASE}:${NEW_TEST_BASE}" \
+    "${OLD_FIXTURE_BASE}:${NEW_FIXTURE_BASE}"; do
+
+    old_rel="${src_pair%%:*}"
+    new_rel="${src_pair##*:}"
+    old_path="${module_dir}${old_rel}"
+    new_path="${module_dir}${new_rel}"
+
+    if [[ -d "$old_path" ]]; then
+      run "mkdir -p \"$(dirname "$new_path")\""
+      run "mv \"$old_path\" \"$new_path\""
+      # 빈 부모 디렉토리 정리
+      run "find \"$(dirname "$old_path")\" -type d -empty -delete 2>/dev/null || true"
+    fi
+  done
+done
+
+# ── 3단계: 모듈 디렉토리 이름 변경 ──────────────────────────────────────────
+
+echo "--- Step 3: Rename module directories ---"
+
+if [[ -d "$PROJECT_ROOT/${OLD_ARTIFACT}" ]]; then
+  run "mv \"$PROJECT_ROOT/${OLD_ARTIFACT}\" \"$PROJECT_ROOT/${NEW_ARTIFACT}\""
+fi
+
+# ── 4단계: CLAUDE.md 베이스 패키지 업데이트 ─────────────────────────────────
+
+echo "--- Step 4: Update CLAUDE.md ---"
+replace_in_file "$PROJECT_ROOT/.claude/CLAUDE.md" "${OLD_GROUP}" "${NEW_PACKAGE}"
+
+# ── 완료 ─────────────────────────────────────────────────────────────────────
+
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "=== DRY-RUN complete. No files were modified. ==="
+  echo "    Run without --dry-run to apply changes."
+else
+  echo "=== Done! Next steps ==="
+  echo "    1. ./gradlew compileJava       # 컴파일 확인"
+  echo "    2. ./gradlew spotlessApply     # 포맷 수정"
+  echo "    3. ./gradlew test              # 테스트 확인"
+  echo "    4. git add -A && git commit -m 'chore: rename project to ${NEW_ARTIFACT}'"
+fi

--- a/scripts/new-domain.sh
+++ b/scripts/new-domain.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# new-domain.sh — 새 도메인을 전 레이어에 걸쳐 스캐폴딩한다.
+#
+# 사용법:
+#   ./scripts/new-domain.sh <DomainName>
+#
+# 예시:
+#   ./scripts/new-domain.sh Order
+#   ./scripts/new-domain.sh Product
+#
+# 생성되는 파일:
+#   Domain:
+#     domain/<DomainName>.java
+#   Application Ports:
+#     application/port/input/command/Create<DomainName>UseCase.java
+#     application/port/input/command/Delete<DomainName>UseCase.java
+#     application/port/input/query/Find<DomainName>Query.java
+#     application/port/output/command/Save<DomainName>Port.java
+#     application/port/output/command/Delete<DomainName>Port.java
+#     application/port/output/query/Find<DomainName>Port.java
+#   Application Services:
+#     application/service/command/Create<DomainName>Service.java
+#     application/service/command/Delete<DomainName>Service.java
+#     application/service/query/Find<DomainName>Service.java
+#   Tests:
+#     application/.../Create<DomainName>ServiceTest.java
+#     application/.../Find<DomainName>ServiceTest.java
+
+set -euo pipefail
+
+# ── 인자 파싱 ─────────────────────────────────────────────────────────────────
+
+usage() {
+  echo "Usage: $0 <DomainName>" >&2
+  echo "  DomainName: PascalCase (e.g. Order, Product, BlogPost)" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then usage; fi
+
+DOMAIN="$1"
+
+if [[ ! "$DOMAIN" =~ ^[A-Z][a-zA-Z0-9]*$ ]]; then
+  echo "Error: DomainName must be PascalCase (e.g. Order, BlogPost)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# ── 프로젝트 메타 정보 추출 ───────────────────────────────────────────────────
+
+# settings.gradle.kts 에서 루트 프로젝트명 추출
+ARTIFACT=$(grep 'rootProject.name' "$PROJECT_ROOT/settings.gradle.kts" \
+  | sed 's/.*= *"\(.*\)".*/\1/')
+
+# 기존 domain 패키지에서 basePackage 추출
+DOMAIN_JAVA_DIRS=$(find "$PROJECT_ROOT/${ARTIFACT}/${ARTIFACT}-domain/src/main/java" \
+  -type d -name "domain" 2>/dev/null | head -1)
+
+if [[ -z "$DOMAIN_JAVA_DIRS" ]]; then
+  echo "Error: Cannot find domain directory. Is the project structure correct?" >&2
+  exit 1
+fi
+
+BASE_PKG=$(echo "$DOMAIN_JAVA_DIRS" \
+  | sed "s|.*/src/main/java/||" \
+  | sed 's|/domain$||' \
+  | tr '/' '.')
+
+echo "=== new-domain ==="
+echo "  artifact   : ${ARTIFACT}"
+echo "  base-pkg   : ${BASE_PKG}"
+echo "  domain     : ${DOMAIN}"
+echo ""
+
+# ── 파생 값 계산 ──────────────────────────────────────────────────────────────
+
+DOMAIN_LOWER="${DOMAIN,}"  # camelCase first letter
+
+PKG_DOMAIN="${BASE_PKG}.domain"
+PKG_APP="${BASE_PKG}.application"
+PKG_CMD_PORT="${PKG_APP}.port.input.command"
+PKG_QUERY_PORT="${PKG_APP}.port.input.query"
+PKG_OUT_CMD="${PKG_APP}.port.output.command"
+PKG_OUT_QUERY="${PKG_APP}.port.output.query"
+PKG_SVC_CMD="${PKG_APP}.service.command"
+PKG_SVC_QUERY="${PKG_APP}.service.query"
+
+MODULE_DOMAIN="${ARTIFACT}/${ARTIFACT}-domain"
+MODULE_APP="${ARTIFACT}/${ARTIFACT}-application"
+
+to_path() { echo "$1" | tr '.' '/'; }
+
+JAVA_DOMAIN="${PROJECT_ROOT}/${MODULE_DOMAIN}/src/main/java/$(to_path "$PKG_DOMAIN")"
+JAVA_APP="${PROJECT_ROOT}/${MODULE_APP}/src/main/java/$(to_path "$PKG_APP")"
+JAVA_TEST="${PROJECT_ROOT}/${MODULE_APP}/src/test/java/$(to_path "$PKG_APP")"
+
+# ── 파일 생성 헬퍼 ───────────────────────────────────────────────────────────
+
+write_file() {
+  local path="$1"
+  local content="$2"
+  if [[ -f "$path" ]]; then
+    echo "  [SKIP] already exists: $path"
+    return
+  fi
+  mkdir -p "$(dirname "$path")"
+  echo "$content" > "$path"
+  echo "  [NEW]  $path"
+}
+
+# ── 1. Domain Entity ─────────────────────────────────────────────────────────
+
+echo "--- Generating domain ---"
+
+write_file "${JAVA_DOMAIN}/${DOMAIN}.java" \
+"package ${PKG_DOMAIN};
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jspecify.annotations.Nullable;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ${DOMAIN} {
+
+  private @Nullable Long id;
+  private String name;
+
+  public static ${DOMAIN} create(String name) {
+    if (name == null || name.isBlank()) {
+      throw new DomainException(ErrorCode.INVALID_ARGUMENT, \"Name must not be blank\");
+    }
+    return new ${DOMAIN}(null, name.strip());
+  }
+
+  public static ${DOMAIN} reconstitute(Long id, String name) {
+    return new ${DOMAIN}(id, name);
+  }
+}"
+
+# ── 2. Inbound Command Ports ──────────────────────────────────────────────────
+
+echo "--- Generating inbound ports ---"
+
+write_file "${JAVA_APP}/port/input/command/Create${DOMAIN}UseCase.java" \
+"package ${PKG_CMD_PORT};
+
+import ${PKG_DOMAIN}.${DOMAIN};
+
+public interface Create${DOMAIN}UseCase {
+
+  ${DOMAIN} create(String name);
+}"
+
+write_file "${JAVA_APP}/port/input/command/Delete${DOMAIN}UseCase.java" \
+"package ${PKG_CMD_PORT};
+
+public interface Delete${DOMAIN}UseCase {
+
+  void delete(Long id);
+}"
+
+# ── 3. Inbound Query Ports ────────────────────────────────────────────────────
+
+write_file "${JAVA_APP}/port/input/query/Find${DOMAIN}Query.java" \
+"package ${PKG_QUERY_PORT};
+
+import ${PKG_DOMAIN}.${DOMAIN};
+
+public interface Find${DOMAIN}Query {
+
+  ${DOMAIN} findById(Long id);
+}"
+
+# ── 4. Outbound Command Ports ─────────────────────────────────────────────────
+
+echo "--- Generating outbound ports ---"
+
+write_file "${JAVA_APP}/port/output/command/Save${DOMAIN}Port.java" \
+"package ${PKG_OUT_CMD};
+
+import ${PKG_DOMAIN}.${DOMAIN};
+
+public interface Save${DOMAIN}Port {
+
+  ${DOMAIN} save(${DOMAIN} ${DOMAIN_LOWER});
+}"
+
+write_file "${JAVA_APP}/port/output/command/Delete${DOMAIN}Port.java" \
+"package ${PKG_OUT_CMD};
+
+public interface Delete${DOMAIN}Port {
+
+  void deleteById(Long id);
+}"
+
+# ── 5. Outbound Query Ports ───────────────────────────────────────────────────
+
+write_file "${JAVA_APP}/port/output/query/Find${DOMAIN}Port.java" \
+"package ${PKG_OUT_QUERY};
+
+import ${PKG_DOMAIN}.${DOMAIN};
+import java.util.Optional;
+
+public interface Find${DOMAIN}Port {
+
+  Optional<${DOMAIN}> findById(Long id);
+}"
+
+# ── 6. Application Services ───────────────────────────────────────────────────
+
+echo "--- Generating application services ---"
+
+write_file "${JAVA_APP}/service/command/Create${DOMAIN}Service.java" \
+"package ${PKG_SVC_CMD};
+
+import ${PKG_CMD_PORT}.Create${DOMAIN}UseCase;
+import ${PKG_DOMAIN}.${DOMAIN};
+import ${PKG_OUT_CMD}.Save${DOMAIN}Port;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Create${DOMAIN}Service implements Create${DOMAIN}UseCase {
+
+  private final Save${DOMAIN}Port save${DOMAIN}Port;
+
+  @Override
+  public ${DOMAIN} create(String name) {
+    ${DOMAIN} ${DOMAIN_LOWER} = ${DOMAIN}.create(name);
+    return save${DOMAIN}Port.save(${DOMAIN_LOWER});
+  }
+}"
+
+write_file "${JAVA_APP}/service/command/Delete${DOMAIN}Service.java" \
+"package ${PKG_SVC_CMD};
+
+import ${PKG_CMD_PORT}.Delete${DOMAIN}UseCase;
+import ${PKG_OUT_CMD}.Delete${DOMAIN}Port;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Delete${DOMAIN}Service implements Delete${DOMAIN}UseCase {
+
+  private final Delete${DOMAIN}Port delete${DOMAIN}Port;
+
+  @Override
+  public void delete(Long id) {
+    delete${DOMAIN}Port.deleteById(id);
+  }
+}"
+
+write_file "${JAVA_APP}/service/query/Find${DOMAIN}Service.java" \
+"package ${PKG_SVC_QUERY};
+
+import ${PKG_QUERY_PORT}.Find${DOMAIN}Query;
+import ${PKG_DOMAIN}.${DOMAIN};
+import ${PKG_DOMAIN}.DomainException;
+import ${PKG_DOMAIN}.ErrorCode;
+import ${PKG_OUT_QUERY}.Find${DOMAIN}Port;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Find${DOMAIN}Service implements Find${DOMAIN}Query {
+
+  private final Find${DOMAIN}Port find${DOMAIN}Port;
+
+  @Override
+  public ${DOMAIN} findById(Long id) {
+    return find${DOMAIN}Port.findById(id)
+        .orElseThrow(() -> new DomainException(ErrorCode.NOT_FOUND, \"${DOMAIN} not found: \" + id));
+  }
+}"
+
+# ── 7. Service Tests ──────────────────────────────────────────────────────────
+
+echo "--- Generating service tests ---"
+
+write_file "${JAVA_TEST}/service/command/Create${DOMAIN}ServiceTest.java" \
+"package ${PKG_SVC_CMD};
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import ${PKG_DOMAIN}.${DOMAIN};
+import ${PKG_OUT_CMD}.Save${DOMAIN}Port;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class Create${DOMAIN}ServiceTest {
+
+  @Mock Save${DOMAIN}Port save${DOMAIN}Port;
+  @InjectMocks Create${DOMAIN}Service sut;
+
+  @Test
+  void create_saves_and_returns_domain() {
+    ${DOMAIN} saved = ${DOMAIN}.reconstitute(1L, \"sample\");
+    when(save${DOMAIN}Port.save(any())).thenReturn(saved);
+
+    ${DOMAIN} result = sut.create(\"sample\");
+
+    assertThat(result.getName()).isEqualTo(\"sample\");
+  }
+}"
+
+write_file "${JAVA_TEST}/service/query/Find${DOMAIN}ServiceTest.java" \
+"package ${PKG_SVC_QUERY};
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import ${PKG_DOMAIN}.${DOMAIN};
+import ${PKG_DOMAIN}.DomainException;
+import ${PKG_OUT_QUERY}.Find${DOMAIN}Port;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class Find${DOMAIN}ServiceTest {
+
+  @Mock Find${DOMAIN}Port find${DOMAIN}Port;
+  @InjectMocks Find${DOMAIN}Service sut;
+
+  @Test
+  void findById_returns_domain_when_found() {
+    ${DOMAIN} domain = ${DOMAIN}.reconstitute(1L, \"sample\");
+    when(find${DOMAIN}Port.findById(1L)).thenReturn(Optional.of(domain));
+
+    ${DOMAIN} result = sut.findById(1L);
+
+    assertThat(result.getId()).isEqualTo(1L);
+  }
+
+  @Test
+  void findById_throws_when_not_found() {
+    when(find${DOMAIN}Port.findById(99L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> sut.findById(99L))
+        .isInstanceOf(DomainException.class);
+  }
+}"
+
+# ── 완료 ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Done! Next steps ==="
+echo "  1. Implement outbound adapter (persist/cache) for ${DOMAIN}"
+echo "  2. Register Beans in ApplicationAutoConfiguration:"
+echo "       Create${DOMAIN}UseCase, Delete${DOMAIN}UseCase, Find${DOMAIN}Query"
+echo "  3. Add REST Controller in adapter-input-api (optional)"
+echo "  4. ./gradlew spotlessApply && ./gradlew compileJava"


### PR DESCRIPTION
## Summary
- `scripts/init-project.sh`: 보일러플레이트를 실제 프로젝트로 초기화 (패키지명·모듈명·디렉토리 일괄 치환)
- `scripts/new-domain.sh`: 새 도메인을 전 레이어에 걸쳐 자동 스캐폴딩
- `.devcontainer/devcontainer.json`: Java 25 + Docker-in-Docker 개발 컨테이너

## Motivation
보일러플레이트를 fork하여 실제 프로젝트로 전환할 때 수작업으로 패키지명과 모듈명을 변경해야 했다.
새 도메인을 추가할 때도 레이어별 파일을 일일이 만들어야 했다. 두 스크립트로 이 진입 장벽을 낮춘다.

## Changes
- `init-project.sh`: dry-run 모드 + git dirty check 안전장치 포함
  - 텍스트 치환: 패키지명, 모듈 참조, 루트 프로젝트명
  - 디렉토리 이름 변경: Java 패키지 디렉토리, 모듈 디렉토리
- `new-domain.sh`: PascalCase 도메인명 입력 → 전 레이어 파일 자동 생성
  - Domain Entity, Create/Delete UseCase, Find Query
  - Save/Delete/Find Outbound Port, Create/Delete/Find Service
  - Create/Find Service Test (Mockito 기반)
- `devcontainer.json`: mcr.microsoft.com/devcontainers/java:1-25-bookworm 기반
  - postCreateCommand: `./gradlew compileJava --no-daemon`
  - port 8080 자동 포워딩

## Test plan
- [ ] `./scripts/new-domain.sh Order` 실행 → 파일 생성 확인
- [ ] `./gradlew compileJava` 통과
- [ ] `./gradlew :boilerplate-domain:test :boilerplate-application:test` 통과
- [ ] `./scripts/init-project.sh com.example myapp --dry-run` 실행 → 변경 목록 출력 확인