### PR TITLE
feat(phase5): HikariCP pool 가이드 및 k6 부하 테스트 스크립트

### DIFF
--- a/boilerplate/boilerplate-boot-api/src/main/resources/application.yml
+++ b/boilerplate/boilerplate-boot-api/src/main/resources/application.yml
@@ -17,6 +17,17 @@ spring:
     driver-class-name: ${DATASOURCE_DRIVER:org.postgresql.Driver}
     username: ${DATASOURCE_USERNAME:boilerplate}
     password: ${DATASOURCE_PASSWORD}
+    hikari:
+      # Virtual Threads + HikariCP 권장 설정 (ADR-0025)
+      # Virtual Thread는 blocking I/O 시 carrier thread를 반환하므로
+      # 전통적인 "thread 수 = pool size" 공식이 맞지 않는다.
+      # 권장: maximumPoolSize = DB 서버 max_connections × 0.8 이하
+      # 시작값으로 20을 권장하며, 부하 테스트 후 조정한다.
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:20}
+      minimum-idle: ${HIKARI_MIN_IDLE:5}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT:30000}
+      idle-timeout: ${HIKARI_IDLE_TIMEOUT:600000}
+      max-lifetime: ${HIKARI_MAX_LIFETIME:1800000}
   flyway:
     locations: classpath:db/migration
   jooq:

--- a/docs/decisions/0024-virtual-threads-hikari-pool-sizing.md
+++ b/docs/decisions/0024-virtual-threads-hikari-pool-sizing.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+date: 2026-04-05
+decision-makers: ppzxc
+---
+
+# Virtual Threads 환경에서 HikariCP Pool Size를 DB 연결 수 기준으로 결정한다
+
+## Context and Problem Statement
+
+Java 25 Virtual Threads를 활성화하면 blocking I/O 시 carrier thread가 반환되므로
+수천 개의 Virtual Thread가 동시에 실행될 수 있다. 이때 HikariCP pool size를
+너무 크게 설정하면 DB max_connections를 초과하고, 너무 작게 설정하면 connection
+timeout이 발생한다. 올바른 pool size 결정 기준이 필요하다.
+
+## Decision Outcome
+
+Chosen option: "DB max_connections 기반 상한 설정 + 환경변수 주입", because
+Virtual Threads 환경에서 연결 경합의 진짜 병목은 thread 수가 아닌 DB 연결 수이므로
+DB 서버의 max_connections × 0.8을 시작값으로 삼고 부하 테스트로 조정한다.
+
+## 구현 사항
+
+- `application.yml`의 `spring.datasource.hikari.*` 설정에 권장 값과 주석 추가
+- 모든 pool 파라미터를 환경변수로 주입 가능하게 구성 (`HIKARI_MAX_POOL_SIZE` 등)
+- 가이드 문서: `docs/guides/virtual-threads-hikari.md`
+- 메트릭 모니터링: `hikaricp.connections.active`, `hikaricp.connections.pending`
+
+## 참고
+
+- [HikariCP — About Pool Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing)
+- [JEP 444 — Virtual Threads](https://openjdk.org/jeps/444)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,6 +30,7 @@
 | [ADR-0021](0021-resilience-strategy.md) | accepted | 외부 서비스 내결함성 전략: Resilience4j core + 프로그래매틱 API |
 | [ADR-0022](0022-contract-testing-strategy.md) | accepted | Spring Cloud Contract로 API 계약 테스트 도입 |
 | [ADR-0023](0023-mutation-testing-strategy.md) | accepted | Mutation Testing으로 테스트 품질 검증 |
+| [ADR-0024](0024-virtual-threads-hikari-pool-sizing.md) | accepted | Virtual Threads 환경 HikariCP Pool Size 결정 기준 |
 
 ## 새 ADR 추가
 

--- a/docs/guides/virtual-threads-hikari.md
+++ b/docs/guides/virtual-threads-hikari.md
@@ -1,0 +1,111 @@
+# Virtual Threads + HikariCP Connection Pool 가이드
+
+> 관련 ADR: [ADR-0025](../decisions/0025-virtual-threads-hikari-pool-sizing.md)
+
+## 핵심 원칙
+
+Java 25 Virtual Threads 환경에서 HikariCP는 **전통적인 pool sizing 공식이 적용되지 않는다**.
+
+전통 방식 (Platform Threads):
+```
+pool size ≈ active thread count
+```
+
+Virtual Threads 방식:
+```
+pool size = min(DB max_connections × 0.8, 실측 동시 DB 쿼리 수)
+```
+
+Virtual Thread는 blocking I/O(DB 대기) 시 carrier thread를 반환하므로, thread 수와 pool size를
+일치시킬 필요가 없다. **DB 연결 수**가 진짜 병목이다.
+
+## 위험 패턴
+
+### 1. Pool Size를 무한정 크게 설정
+
+```yaml
+# 위험: DB 서버가 max_connections를 초과하면 연결 거부됨
+hikari:
+  maximum-pool-size: 1000
+```
+
+### 2. Pool Size를 너무 작게 설정
+
+```yaml
+# 위험: 고부하 시 connection timeout 발생
+hikari:
+  maximum-pool-size: 5
+```
+
+### 3. connectionTimeout 미설정
+
+HikariCP 기본값은 30초. Virtual Threads로 요청이 폭증하면 모든 요청이 30초씩 대기한다.
+빠른 실패를 위해 더 짧게 설정하는 것을 권장한다.
+
+## 권장 설정
+
+```yaml
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: ${HIKARI_MAX_POOL_SIZE:20}   # DB max_connections × 0.8 이하
+      minimum-idle: ${HIKARI_MIN_IDLE:5}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT:30000}  # 30초 (빠른 실패 원하면 5000)
+      idle-timeout: ${HIKARI_IDLE_TIMEOUT:600000}     # 10분
+      max-lifetime: ${HIKARI_MAX_LIFETIME:1800000}    # 30분
+```
+
+## Pool Size 결정 방법
+
+1. **DB 서버 max_connections 확인**
+   ```sql
+   SHOW max_connections;  -- PostgreSQL
+   ```
+
+2. **시작값 계산**
+   ```
+   maximumPoolSize = max_connections × 0.8 (다른 클라이언트/관리 커넥션 여유)
+   ```
+   예: max_connections=100 → maximumPoolSize=80
+
+3. **부하 테스트로 검증**
+   ```bash
+   # scripts/load-test/todo-crud.js 실행
+   k6 run scripts/load-test/todo-crud.js
+   ```
+
+4. **Micrometer 메트릭으로 모니터링**
+   - `hikaricp.connections.active` — 현재 사용 중인 연결 수
+   - `hikaricp.connections.pending` — 연결 대기 중인 요청 수
+   - `hikaricp.connections.timeout.total` — timeout 발생 횟수
+
+   `pending > 0` 이 지속되면 pool size 부족. `timeout` 발생 시 즉시 증설.
+
+## Virtual Threads에서 주의할 점
+
+### synchronized 블록 사용 금지
+
+HikariCP 내부에 `synchronized`가 있으면 Virtual Thread가 carrier thread를 **핀닝(pinning)**한다.
+HikariCP 6.x 이상에서는 이 문제가 해결되었다. 최신 버전을 유지할 것.
+
+```bash
+# 핀닝 감지 JVM 옵션 (개발 시 사용)
+-Djdk.tracePinnedThreads=full
+```
+
+### connection-timeout vs query timeout
+
+- `connection-timeout`: pool에서 연결을 **빌리는** 시간 제한
+- DB query timeout: 실제 쿼리 실행 시간 제한 (jOOQ: `settings.queryTimeout`)
+
+두 설정을 독립적으로 관리할 것.
+
+## 환경변수 목록
+
+| 변수 | 설명 | 권장값 |
+|------|------|--------|
+| `HIKARI_MAX_POOL_SIZE` | 최대 연결 수 | `max_connections × 0.8` |
+| `HIKARI_MIN_IDLE` | 최소 유휴 연결 수 | `5` |
+| `HIKARI_CONNECTION_TIMEOUT` | 연결 획득 타임아웃 (ms) | `30000` |
+| `HIKARI_IDLE_TIMEOUT` | 유휴 연결 유지 시간 (ms) | `600000` |
+| `HIKARI_MAX_LIFETIME` | 연결 최대 수명 (ms) | `1800000` |

--- a/scripts/load-test/todo-crud.js
+++ b/scripts/load-test/todo-crud.js
@@ -1,0 +1,187 @@
+/**
+ * Todo CRUD 부하 테스트 — k6
+ *
+ * 사용법:
+ *   k6 run scripts/load-test/todo-crud.js
+ *   k6 run --vus 50 --duration 60s scripts/load-test/todo-crud.js
+ *   BASE_URL=http://staging:8080 k6 run scripts/load-test/todo-crud.js
+ *
+ * 시나리오:
+ *   1. Todo 생성 (POST /api/todos)
+ *   2. 생성된 Todo 조회 (GET /api/todos/{id})
+ *   3. Todo 목록 조회 (GET /api/todos)
+ *   4. Todo 완료 처리 (PUT /api/todos/{id})
+ *   5. Todo 삭제 (DELETE /api/todos/{id})
+ *
+ * 결과 해석:
+ *   - http_req_duration p(95) < 200ms → 양호
+ *   - http_req_failed < 1% → 양호
+ *   - hikaricp_connections_pending > 0 지속 → pool size 부족
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+// ── 설정 ────────────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+
+export const options = {
+  scenarios: {
+    // 점진적 증가 (워밍업 → 정상 부하 → 피크 → 쿨다운)
+    ramp_up: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: 10 }, // 워밍업
+        { duration: "1m", target: 30 }, // 정상 부하
+        { duration: "30s", target: 60 }, // 피크 부하
+        { duration: "30s", target: 0 }, // 쿨다운
+      ],
+    },
+  },
+  thresholds: {
+    // 95번째 백분위 응답시간 < 500ms
+    http_req_duration: ["p(95)<500"],
+    // 오류율 < 1%
+    http_req_failed: ["rate<0.01"],
+    // 생성 API 95th < 300ms
+    "todo_create_duration": ["p(95)<300"],
+    // 조회 API 95th < 200ms
+    "todo_find_duration": ["p(95)<200"],
+  },
+};
+
+// ── 커스텀 메트릭 ────────────────────────────────────────────────────────────
+
+const todoCreateDuration = new Trend("todo_create_duration");
+const todoFindDuration = new Trend("todo_find_duration");
+const errorRate = new Rate("error_rate");
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+const headers = { "Content-Type": "application/json" };
+
+function createTodo(title) {
+  const start = Date.now();
+  const res = http.post(
+    `${BASE_URL}/api/todos`,
+    JSON.stringify({ title }),
+    { headers }
+  );
+  todoCreateDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    "create: status 201": (r) => r.status === 201,
+    "create: has id": (r) => {
+      try {
+        return JSON.parse(r.body).id !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  errorRate.add(!ok);
+  return ok ? JSON.parse(res.body) : null;
+}
+
+function findTodo(id) {
+  const start = Date.now();
+  const res = http.get(`${BASE_URL}/api/todos/${id}`, { headers });
+  todoFindDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    "find: status 200": (r) => r.status === 200,
+  });
+  errorRate.add(!ok);
+  return ok ? JSON.parse(res.body) : null;
+}
+
+function listTodos() {
+  const start = Date.now();
+  const res = http.get(`${BASE_URL}/api/todos`, { headers });
+  todoFindDuration.add(Date.now() - start);
+
+  const ok = check(res, {
+    "list: status 200": (r) => r.status === 200,
+    "list: has Total-Count header": (r) =>
+      r.headers["Total-Count"] !== undefined,
+  });
+  errorRate.add(!ok);
+}
+
+function updateTodo(id, completed) {
+  const res = http.put(
+    `${BASE_URL}/api/todos/${id}`,
+    JSON.stringify({ completed }),
+    { headers }
+  );
+  const ok = check(res, {
+    "update: status 200": (r) => r.status === 200,
+  });
+  errorRate.add(!ok);
+}
+
+function deleteTodo(id) {
+  const res = http.del(`${BASE_URL}/api/todos/${id}`, null, { headers });
+  const ok = check(res, {
+    "delete: status 204": (r) => r.status === 204,
+  });
+  errorRate.add(!ok);
+}
+
+// ── 메인 시나리오 ─────────────────────────────────────────────────────────────
+
+export default function () {
+  // 1. 생성
+  const title = `load-test-todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const created = createTodo(title);
+  if (!created) return;
+
+  sleep(0.1);
+
+  // 2. 단건 조회
+  findTodo(created.id);
+
+  sleep(0.1);
+
+  // 3. 목록 조회
+  listTodos();
+
+  sleep(0.1);
+
+  // 4. 완료 처리
+  updateTodo(created.id, true);
+
+  sleep(0.1);
+
+  // 5. 삭제
+  deleteTodo(created.id);
+
+  sleep(0.5);
+}
+
+// ── 테스트 종료 요약 ──────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+  return {
+    stdout: JSON.stringify(
+      {
+        "http_req_duration_p95_ms":
+          data.metrics.http_req_duration?.values?.["p(95)"]?.toFixed(1),
+        "http_req_failed_rate_%": (
+          (data.metrics.http_req_failed?.values?.rate || 0) * 100
+        ).toFixed(2),
+        "todo_create_p95_ms":
+          data.metrics.todo_create_duration?.values?.["p(95)"]?.toFixed(1),
+        "todo_find_p95_ms":
+          data.metrics.todo_find_duration?.values?.["p(95)"]?.toFixed(1),
+        "vus_max": data.metrics.vus_max?.values?.max,
+        "iterations": data.metrics.iterations?.values?.count,
+      },
+      null,
+      2
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- `application.yml`: HikariCP 권장 설정 + Virtual Threads 주의사항 주석 추가
- `docs/guides/virtual-threads-hikari.md`: pool sizing 원칙, 위험 패턴, 모니터링 가이드
- `docs/decisions/0024`: Virtual Threads 환경 HikariCP Pool Size 결정 ADR
- `scripts/load-test/todo-crud.js`: k6 ramping-vus 시나리오 (워밍업→정상→피크→쿨다운)

## Motivation
Virtual Threads 환경에서 HikariCP pool size를 잘못 설정하면 DB 연결 초과(너무 큼) 또는
connection timeout(너무 작음)이 발생한다. 결정 근거와 권장 설정을 문서화하고,
실제 부하 테스트로 검증할 수 있는 k6 스크립트를 제공한다.

## Changes
- `application.yml` hikari 블록: `HIKARI_MAX_POOL_SIZE`, `HIKARI_MIN_IDLE` 등 환경변수 주입
- 가이드: pool size 결정 방법, synchronized 핀닝 경고, Micrometer 메트릭 목록
- k6 시나리오: 5단계 CRUD (생성→조회→목록→수정→삭제), `p(95)<500ms`, `error_rate<1%` 임계값

## Test plan
- [ ] `./gradlew compileJava` 통과
- [ ] `k6 run scripts/load-test/todo-crud.js` 실행 (서버 실행 중 필요)
- [ ] `hikaricp.connections.active` 메트릭 Actuator로 확인