### PR TITLE
test(coverage): add JaCoCo 80% gate and adapter unit tests

### DIFF
--- a/boilerplate/boilerplate-adapter-output-cache/src/test/java/io/github/ppzxc/boilerplate/adapter/output/cache/CaffeineTodoCacheAdapterTest.java
+++ b/boilerplate/boilerplate-adapter-output-cache/src/test/java/io/github/ppzxc/boilerplate/adapter/output/cache/CaffeineTodoCacheAdapterTest.java
@@ -1,6 +1,7 @@
 package io.github.ppzxc.boilerplate.adapter.output.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,8 +74,7 @@ class CaffeineTodoCacheAdapterTest {
     Todo todo = TodoFixtures.savedTodo(1L, "title", false);
     when(cacheManager.getCache("todos")).thenReturn(null);
 
-    adapter.put(todo);
-    // 예외 없이 종료
+    assertThatCode(() -> adapter.put(todo)).doesNotThrowAnyException();
   }
 
   @Test
@@ -90,7 +90,6 @@ class CaffeineTodoCacheAdapterTest {
   void evict_does_nothing_when_cache_is_null() {
     when(cacheManager.getCache("todos")).thenReturn(null);
 
-    adapter.evict(1L);
-    // 예외 없이 종료
+    assertThatCode(() -> adapter.evict(1L)).doesNotThrowAnyException();
   }
 }

--- a/boilerplate/boilerplate-adapter-output-external/src/test/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClientTest.java
+++ b/boilerplate/boilerplate-adapter-output-external/src/test/java/io/github/ppzxc/boilerplate/adapter/output/external/ExternalApiClientTest.java
@@ -46,7 +46,7 @@ class ExternalApiClientTest {
   }
 
   @Test
-  void fetchById_retries_on_failure_then_propagates() {
+  void fetchById_retry_metrics_recorded_when_circuit_breaker_rejects() {
     CircuitBreakerConfig cbConfig =
         CircuitBreakerConfig.custom()
             .slidingWindowSize(2)

--- a/boilerplate/boilerplate-application/build.gradle.kts
+++ b/boilerplate/boilerplate-application/build.gradle.kts
@@ -13,22 +13,6 @@ extensions.configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
   jvmArgs.set(listOf("-XX:+EnableDynamicAgentLoading"))
 }
 
-tasks.jacocoTestCoverageVerification {
-  dependsOn(tasks.jacocoTestReport)
-  violationRules {
-    rule {
-      limit {
-        counter = "LINE"
-        minimum = "0.80".toBigDecimal()
-      }
-    }
-  }
-}
-
-tasks.named("check") {
-  dependsOn(tasks.jacocoTestCoverageVerification)
-}
-
 dependencies {
   api(project(":boilerplate-domain"))
   testImplementation(testFixtures(project(":boilerplate-domain")))

--- a/boilerplate/boilerplate-application/gradle.properties
+++ b/boilerplate/boilerplate-application/gradle.properties
@@ -1,1 +1,1 @@
-label=java
+label=java,coverage-gate

--- a/boilerplate/boilerplate-domain/build.gradle.kts
+++ b/boilerplate/boilerplate-domain/build.gradle.kts
@@ -13,22 +13,6 @@ extensions.configure<info.solidsoft.gradle.pitest.PitestPluginExtension> {
   jvmArgs.set(listOf("-XX:+EnableDynamicAgentLoading"))
 }
 
-tasks.jacocoTestCoverageVerification {
-  dependsOn(tasks.jacocoTestReport)
-  violationRules {
-    rule {
-      limit {
-        counter = "LINE"
-        minimum = "0.80".toBigDecimal()
-      }
-    }
-  }
-}
-
-tasks.named("check") {
-  dependsOn(tasks.jacocoTestCoverageVerification)
-}
-
 dependencies {
   testImplementation(rootProject.libs.net.jqwik)
 }

--- a/boilerplate/boilerplate-domain/gradle.properties
+++ b/boilerplate/boilerplate-domain/gradle.properties
@@ -1,1 +1,1 @@
-label=java
+label=java,coverage-gate

--- a/boilerplate/boilerplate-domain/src/test/java/io/github/ppzxc/boilerplate/domain/TodoPropertyTest.java
+++ b/boilerplate/boilerplate-domain/src/test/java/io/github/ppzxc/boilerplate/domain/TodoPropertyTest.java
@@ -104,6 +104,7 @@ class TodoPropertyTest {
    *
    * <p>complete(), uncomplete(), updateTitle() 호출 후에도 원본 Todo의 상태는 변하지 않아야 한다.
    */
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Property
   void mutation_methods_do_not_modify_original(
       @ForAll @AlphaChars @StringLength(min = 1, max = 50) String title,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,6 +206,26 @@ configureByLabel("mapstruct") {
   }
 }
 
+// ── coverage-gate 라벨: JaCoCo 80% 라인 커버리지 게이트 ──────────────
+// domain, application 모듈에만 적용 (adapter/boot 모듈 제외)
+configureByLabel("coverage-gate") {
+  tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+      rule {
+        limit {
+          counter = "LINE"
+          minimum = "0.80".toBigDecimal()
+        }
+      }
+    }
+  }
+
+  tasks.named("check") {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+  }
+}
+
 // ── jooq 라벨: jOOQ Codegen + H2 ──────────────────────────────────
 configureByLabel("jooq") {
   apply(plugin = rootProject.libs.plugins.org.jooq.codegen.gradle.get().pluginId)


### PR DESCRIPTION
## Summary
- domain/application 모듈에 JaCoCo 80% 라인 커버리지 게이트 추가
- CI coverage-report job 커버리지 검증 강제화 (`continue-on-error` 제거)
- `CaffeineTodoCacheAdapter` 단위 테스트 7개 추가
- `ExternalApiClient` Resilience4j 동작 검증 테스트 5개 추가
- `Todo` jqwik 속성 테스트 불변식 5~7 추가 (멱등성, 불변성)

## Motivation
어댑터 모듈에 테스트가 전혀 없었고, 커버리지가 CI에서 강제되지 않았다.
Phase 1 코드 품질 개선의 일환으로 커버리지 게이트와 누락된 테스트를 추가한다.

## Changes
- `boilerplate-domain/build.gradle.kts`: `jacocoTestCoverageVerification` 80% 설정
- `boilerplate-application/build.gradle.kts`: `jacocoTestCoverageVerification` 80% 설정
- `.github/workflows/test.yml`: `continue-on-error` 제거, Verify coverage gate step 추가
- `CaffeineTodoCacheAdapterTest.java`: get/put/evict 단위 테스트 7개
- `ExternalApiClientTest.java`: CircuitBreaker/Retry/RateLimiter 패턴 검증 5개
- `TodoPropertyTest.java`: 불변식 5~7 추가 (jqwik)

## Test plan
- [ ] `./gradlew :boilerplate-domain:test` 통과
- [ ] `./gradlew :boilerplate-application:test` 통과
- [ ] `./gradlew :boilerplate-adapter-output-cache:test` 통과 (7 tests)
- [ ] `./gradlew :boilerplate-adapter-output-external:test` 통과 (5 tests)
- [ ] `./gradlew :boilerplate-domain:jacocoTestCoverageVerification` 통과
- [ ] `./gradlew :boilerplate-application:jacocoTestCoverageVerification` 통과