### PR TITLE
fix(tests): fix TransactionRollbackIT CI failure with Testcontainers

### DIFF
--- a/boilerplate/boilerplate-boot-api/src/test/java/io/github/ppzxc/boilerplate/TransactionRollbackIT.java
+++ b/boilerplate/boilerplate-boot-api/src/test/java/io/github/ppzxc/boilerplate/TransactionRollbackIT.java
@@ -7,29 +7,61 @@ import io.github.ppzxc.boilerplate.dummy.DummyAdapter;
 import io.github.ppzxc.boilerplate.dummy.SaveDummyPort;
 import io.github.ppzxc.boilerplate.dummy.TriggerExceptionService;
 import io.github.ppzxc.boilerplate.dummy.TriggerExceptionUseCase;
+import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest
+@SpringBootTest(
+    properties =
+        "spring.autoconfigure.exclude="
+            + "io.github.springwolf.core.configuration.SpringwolfAutoConfiguration,"
+            + "io.github.springwolf.plugins.stomp.configuration.SpringwolfStompAutoConfiguration,"
+            + "io.github.springwolf.bindings.stomp.configuration.SpringwolfStompBindingAutoConfiguration")
 @Import(TransactionRollbackIT.TestConfig.class)
+@Testcontainers
 class TransactionRollbackIT {
 
+  @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17");
+
+  @DynamicPropertySource
+  static void configureProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+    registry.add("spring.jooq.sql-dialect", () -> "POSTGRES");
+  }
+
   @TestConfiguration
-  @EnableTransactionManagement
   static class TestConfig {
     @Bean
-    @Transactional
-    public TriggerExceptionUseCase triggerExceptionUseCase(SaveDummyPort port) {
-      return new TriggerExceptionService(port);
+    public TriggerExceptionUseCase triggerExceptionUseCase(
+        SaveDummyPort port, PlatformTransactionManager txManager) {
+      TransactionInterceptor interceptor = new TransactionInterceptor();
+      interceptor.setTransactionManager(txManager);
+      Properties attrs = new Properties();
+      attrs.setProperty("*", "PROPAGATION_REQUIRED");
+      interceptor.setTransactionAttributes(attrs);
+
+      ProxyFactory factory = new ProxyFactory(new TriggerExceptionService(port));
+      factory.addInterface(TriggerExceptionUseCase.class);
+      factory.addAdvice(interceptor);
+      return TriggerExceptionUseCase.class.cast(factory.getProxy());
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,7 +141,7 @@ configureByLabel("java") {
       googleJavaFormat(
         versionCatalog.findVersion("com-google-googlejavaformat").get().requiredVersion
       )
-      targetExclude("**/build/generated/**")
+      targetExclude("**/build/generated/**", "**/build/generated-sources/**")
     }
   }
 


### PR DESCRIPTION
## Summary
- `TransactionRollbackIT`에 Testcontainers + PostgreSQLContainer 추가로 CI에서 DB 연결 실패 문제 해결
- `@Bean @Transactional` 패턴을 `TransactionInterceptor` + `ProxyFactory` 방식으로 교체
- Spotless `targetExclude`에 `build/generated-sources/**` 패턴 추가

## Motivation
CI Integration Tests 잡이 `Connection to localhost:5432 refused`로 지속 실패.
원인은 두 가지: (1) Testcontainers 미설정으로 Flyway가 localhost DB에 연결 시도,
(2) `@Bean @Transactional` 은 반환된 서비스 객체에 트랜잭션 프록시를 생성하지 않아
트랜잭션 롤백 검증 로직이 항상 실패.

## Changes
- `TransactionRollbackIT`: `@Testcontainers`, `@Container PostgreSQLContainer`, `@DynamicPropertySource`, Springwolf 자동설정 제외 추가
- `TransactionRollbackIT.TestConfig`: `@Transactional` 팩토리 메서드 → `txProxy` 패턴으로 교체
- `build.gradle.kts`: Spotless `targetExclude`에 `**/build/generated-sources/**` 추가

## Test plan
- [ ] `./gradlew :boilerplate-boot-api:test --tests "*.TransactionRollbackIT"` 통과
- [ ] `./gradlew :boilerplate-adapter-output-persist:test :boilerplate-boot-api:test` 통과
- [ ] CI Integration Tests 잡 통과