### PR TITLE
docs(rules): playbook 대비 rules/ADR 갭 동기화 (8개 rules 파일 + 5개 ADR)

### DIFF
--- a/.claude/rules/cicd.md
+++ b/.claude/rules/cicd.md
@@ -1,5 +1,5 @@
 ---
-description: CI/CD 핵심 정책 — 보안 스캔 게이트, 배포 전략, 환경별 설정
+description: CI/CD 핵심 정책 — 보안 스캔 게이트, 배포 전략, Jib 빌드, GitHub Actions, 릴리스 관리
 alwaysApply: true
 ---
 
@@ -8,7 +8,6 @@ alwaysApply: true
 CI/CD 핵심 정책 — 항상 로드.
 
 > **요구 수준 키워드**: MUST, MUST NOT, SHOULD는 RFC 2119 기준.
-> 인프라 설정(Jenkinsfile, GitHub Actions workflow 상세)은 이 파일 범위 외.
 
 ---
 
@@ -96,6 +95,192 @@ spring:
 - MUST: `/actuator/health/readiness` 가 `UP`을 반환한 후 트래픽 라우팅을 전환한다.
 - MUST NOT: 컨테이너 시작 직후 바로 트래픽을 라우팅한다 (Spring Context 초기화 시간 필요).
 - MUST: Liveness probe 실패 시 컨테이너를 재시작하는 정책을 설정한다.
+
+---
+
+## 6. Jib 컨테이너 이미지 빌드
+
+Docker 파일 없이 OCI 이미지를 빌드. CI/CD 파이프라인에서 Gradle로 직접 이미지 생성.
+
+> 근거: ADR-0017
+
+```kotlin
+// boilerplate-boot-api/build.gradle.kts
+plugins {
+    id("com.google.cloud.tools.jib") version "3.x.x"  // libs.versions.toml에서 최신 버전 확인
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:25-jre"
+    }
+    to {
+        image = "ghcr.io/ppzxc/boilerplate"
+        tags = setOf("latest", project.version.toString())
+    }
+    container {
+        jvmFlags = listOf(
+            "-XX:+UseZGC",                          // ZGC — 저지연 GC (Java 25 기본)
+            "-XX:+ZGenerational",                    // Generational ZGC
+            "-XX:MaxRAMPercentage=75.0",             // 컨테이너 메모리 75% 제한
+            "-Djava.security.egd=file:/dev/urandom"  // 빠른 난수 초기화
+        )
+        ports = listOf("8080")
+        environment = mapOf(
+            "SPRING_PROFILES_ACTIVE" to "prod"
+        )
+    }
+}
+```
+
+- MUST: `jib.to.image`에 버전 태그와 `latest` 태그를 모두 포함한다.
+- MUST: JVM 플래그에 ZGC(`-XX:+UseZGC`)를 포함한다. Java 25의 기본 GC이나 명시적으로 설정한다.
+- MUST: `-XX:MaxRAMPercentage`로 컨테이너 메모리 상한을 설정한다.
+- MUST NOT: `Dockerfile`을 직접 작성하여 이미지를 빌드한다. Jib을 사용한다.
+
+**CD 워크플로우 (push step)**
+
+```yaml
+# .github/workflows/cd.yml (일부)
+- name: Build and push image
+  run: ./gradlew :boilerplate-boot-api:jib
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+---
+
+## 7. GitHub Actions CI 파이프라인
+
+> 근거: ADR-0018
+
+모든 PR에 대해 5개 게이트를 순서대로 실행한다.
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      # Gate 1: 컴파일 + 코드 품질
+      - name: Compile & Code Quality
+        run: ./gradlew compileJava spotlessCheck checkstyleMain --no-daemon
+
+      # Gate 2: 단위/통합 테스트 + 커버리지
+      - name: Test & Coverage
+        run: ./gradlew test jacocoTestCoverageVerification --no-daemon
+
+      # Gate 3: 정적 분석 (ErrorProne + NullAway — compileJava에 포함)
+      - name: Static Analysis
+        run: ./gradlew compileTestJava --no-daemon
+
+      # Gate 4: Modulith 구조 검증 + ArchUnit
+      - name: Architecture Verification
+        run: ./gradlew test --tests "*ModulithStructureTest*" --tests "*ArchitectureTest*" --no-daemon
+
+      # Gate 5: 보안 취약점 스캔
+      - name: Security Scan (OWASP)
+        run: ./gradlew dependencyCheckAnalyze --no-daemon
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+```
+
+- MUST: CI 파이프라인은 `pull_request` + `push` 이벤트 모두에서 실행한다.
+- MUST: Gradle 실행 시 `--no-daemon` 플래그를 포함한다 (메모리 누수 방지 — harness.md §2 참조).
+- MUST: Java 캐시를 활성화하여 빌드 시간을 단축한다 (`cache: 'gradle'`).
+- MUST: NVD API Key를 GitHub Secrets에 등록한다. 없으면 OWASP 스캔이 느려짐.
+- MUST NOT: `secrets.*`를 코드에 하드코딩한다.
+
+---
+
+## 8. 릴리스 관리
+
+### Semantic Versioning
+
+- MUST: 버전 형식은 `MAJOR.MINOR.PATCH` (SemVer 2.0).
+- MUST: Breaking Change → MAJOR 증가. 새 기능 → MINOR 증가. 버그 수정 → PATCH 증가.
+- MUST NOT: SNAPSHOT, RC 등 비표준 접미사를 운영 배포에 사용한다.
+
+| 변경 유형 | 예시 | 버전 변경 |
+|----------|------|---------|
+| Breaking API change | Command/Event 스키마 비호환 변경 | 1.0.0 → 2.0.0 |
+| 새 기능 (호환) | 신규 UseCase 추가 | 1.0.0 → 1.1.0 |
+| 버그 수정 | 특정 조건에서의 NPE 수정 | 1.0.0 → 1.0.1 |
+
+### Git 태깅
+
+```bash
+# 릴리스 태그 생성 (v 접두어 필수)
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+- MUST: 릴리스 태그는 `v{MAJOR}.{MINOR}.{PATCH}` 형식 (`v` 접두어 필수).
+- MUST NOT: `main` 브랜치에 직접 태그를 수동으로 붙이지 않는다. GitHub Actions Release 워크플로우를 통해 자동화한다.
+
+### Release 워크플로우
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Build image and push
+        run: ./gradlew :boilerplate-boot-api:jib -Pversion=${{ steps.version.outputs.version }} --no-daemon
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}
+```
+
+- MUST: Release 워크플로우는 `v*` 태그 푸시 이벤트에만 실행한다.
+- MUST: `packages: write` 권한으로 GHCR에 이미지를 푸시한다.
+- MUST: `generate_release_notes: true`로 GitHub이 PR 기반 릴리스 노트를 자동 생성한다.
 
 ---
 

--- a/.claude/rules/cqrs.md
+++ b/.claude/rules/cqrs.md
@@ -256,6 +256,23 @@ public void execute(TransferCommand cmd) {
 
 ---
 
+## 8.1. 동시성 제어 원칙
+
+멱등성이 "동일 요청의 중복 실행"을 방어한다면, 동시성 제어는 "서로 다른 요청이 동일 리소스를 동시에 변경하려 할 때"의 경합을 방어한다.
+
+| 전략 | 동작 방식 | 적합한 상황 |
+|------|-----------|-------------|
+| **Optimistic Lock** | Entity의 version 필드 기반, 갱신 시 version 불일치면 실패 | 충돌 빈도가 낮은 일반적인 경우 (기본 권장) |
+| **Pessimistic Lock** | DB 레코드를 `SELECT ... FOR UPDATE`로 잠금 | 충돌 빈도가 높고 반드시 순차 처리가 필요한 경우 |
+| **Compare-And-Set** | 상태 전이 조건을 WHERE 절에 포함하여 원자적 갱신 | 상태 머신 기반 전이 (예: `PENDING → APPROVED`) |
+
+- MUST: 모든 SavePort 구현체는 UPDATE 시 Aggregate의 `version` 필드를 WHERE 조건에 포함한다.
+- MUST: 영향 행이 0이면 도메인 예외를 발생시킨다 (Optimistic Lock 실패).
+- MUST: Pessimistic Lock 사용 시 근거를 ADR에 명시한다.
+- SHOULD: Optimistic Lock을 기본으로 선택한다.
+
+---
+
 ## 9. 이벤트 흐름 (A-6)
 
 ### A-6 Application Service에서 EventPublisher 직접 호출 금지

--- a/.claude/rules/harness.md
+++ b/.claude/rules/harness.md
@@ -186,6 +186,158 @@ tasks.withType<JavaCompile> {
 
 ---
 
+## 7. test-support 모듈
+
+- MUST: 모든 BC의 테스트는 `test-support` 모듈을 `testImplementation`으로 의존한다. 하네스 코드 중복 금지.
+- MUST: test-support 모듈은 DomainTestBase, AdapterTestBase, Fixture Factory 등 공용 테스트 인프라를 제공한다.
+
+```kotlin
+// 각 모듈 build.gradle.kts
+dependencies {
+    testImplementation(project(":test-support"))
+}
+```
+
+### 7.1 DomainTestBase
+
+Domain 테스트의 공통 기반. Spring Context 절대 금지.
+
+```java
+// test-support/src/main/java/.../DomainTestBase.java
+public abstract class DomainTestBase {
+    protected static final Instant NOW = Instant.parse("2026-01-15T10:00:00Z");
+    protected static final Instant LATER = NOW.plusHours(1);
+
+    protected static UUID fixedUuidV7(long epochMillis) {
+        long msb = (epochMillis << 16) | 0x7000L | 0x0001L;
+        long lsb = 0x8000000000000001L;
+        return new UUID(msb, lsb);
+    }
+}
+```
+
+### 7.2 Testcontainers Singleton
+
+모든 Adapter 통합 테스트가 공유하는 단일 PostgreSQL 컨테이너.
+
+```java
+// test-support/src/main/java/.../AdapterTestBase.java
+@SpringBootTest
+@Testcontainers
+public abstract class AdapterTestBase {
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:17")
+        .withDatabaseName("app").withUsername("app").withPassword("app");
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}
+```
+
+- MUST: `@Container` + `static`으로 테스트 클래스 간 컨테이너 재사용 (Singleton 패턴).
+
+### 7.3 DB 클린업
+
+- MUST: 각 테스트 메서드 전에 `@BeforeEach`에서 TRUNCATE로 데이터 초기화. `flyway_schema_history`와 `event_publication` 제외.
+
+### 7.4 Fixture Factory
+
+- MUST: Fixture 생성 시 `reconstitute()`를 사용한다. `create()`는 이벤트를 발행하므로 상태 설정 Fixture에 부적합.
+- MUST: 고정 `Instant`를 사용한다. `Instant.now()` 호출 금지.
+
+### 7.5 Clock 제어
+
+- MUST: 테스트 환경에서 `Clock.fixed()`를 Bean으로 등록하여 결정적 시간 제어.
+
+---
+
+## 8. Lefthook (로컬 Git Hooks)
+
+Lefthook은 Git hooks 관리자. CI 전 로컬에서 품질 검사를 실행하여 위반 코드 커밋/푸시 차단.
+
+```kotlin
+// build.gradle.kts
+plugins {
+    alias(libs.plugins.com.fizzpod.lefthook)
+}
+```
+
+```yaml
+# lefthook.yml
+pre-commit:
+  jobs:
+    - name: spotless-check
+      run: ./gradlew spotlessCheck
+    - name: checkstyle
+      glob: "*.java"
+      run: ./gradlew checkstyleMain
+
+pre-push:
+  jobs:
+    - name: unit-tests
+      run: ./gradlew test -x :*:adapter-*:test -x :*:configuration:test
+    - name: archunit
+      run: ./gradlew test --tests "*ArchitectureTest*"
+```
+
+- SHOULD: `lefthook.yml`은 리포지토리에 버전 관리. 팀 전원 동일 hooks. 로컬 오버라이드는 `lefthook-local.yml`(gitignore).
+- MUST: `./gradlew lefthookInstall`로 Git hooks 자동 설치.
+
+---
+
+## 9. PIT Mutation Testing
+
+PIT는 소스 코드에 의도적 변이(mutation)를 주입하고, 테스트가 이를 감지(kill)하는지 확인한다.
+
+```kotlin
+// 모듈별 적용
+pitest {
+    junit5PluginVersion.set("1.2.1")
+    targetClasses.set(setOf("io.github.ppzxc.boilerplate.*"))
+    threads.set(Runtime.getRuntime().availableProcessors())
+    outputFormats.set(setOf("HTML", "XML"))
+    timestampedReports.set(false)
+    mutationThreshold.set(80)
+    coverageThreshold.set(70)
+}
+```
+
+- MUST: domain, application 모듈에 PIT를 적용한다. mutationThreshold 80% 미달 시 빌드 실패.
+- JaCoCo(양적 검증) + PIT(질적 검증)을 보완적으로 사용한다.
+
+---
+
+## 10. OpenRewrite
+
+OpenRewrite는 자동 코드 리팩토링 엔진. 감지뿐 아니라 자동 수정을 수행한다.
+
+```kotlin
+apply(plugin = "org.openrewrite.rewrite")
+configure<RewriteExtension> {
+    configFile = rootProject.file("rewrite.yml")
+    activeRecipe("io.github.ppzxc.boilerplate.CodeQuality")
+}
+dependencies {
+    add("rewrite", libs.org.openrewrite.recipe.static.analysis)
+    add("rewrite", libs.org.openrewrite.recipe.migrate.java)
+    add("rewrite", libs.org.openrewrite.recipe.spring)
+}
+```
+
+| 레시피 | 역할 |
+|--------|------|
+| `static-analysis` | 불필요 import 제거, `final` 추가, 빈 블록 제거 |
+| `migrate-java` | Java 25 API 활용, deprecated API 교체 |
+| `spring` | Spring Boot 4 API 변경 자동 적용 |
+
+- SHOULD: `./gradlew rewriteDryRun`으로 미리보기 후 `./gradlew rewriteRun`으로 자동 수정.
+
+---
+
 ## fallback 지시문
 
 > 위 규칙을 현재 상황에 적용하기 어렵거나 규칙 간 충돌이 발생하면,

--- a/.claude/rules/modulith.md
+++ b/.claude/rules/modulith.md
@@ -24,6 +24,8 @@ Modulith 하이브리드 전략 규칙 — 항상 로드.
 
 - MUST: 신규 BC 추가 시 Gradle 멀티모듈 + `@Modulithic` 등록 모두 수행한다.
 - MUST NOT: Common 유틸리티 모듈 (`*-common`, `*-util`)을 생성한다. 공유는 `shared-event` 모듈(이벤트만) 또는 test-support(픽스처만)로 제한한다.
+- MUST: 멀티 모듈 구조를 사용한다. 단일 모듈 구조는 허용하지 않는다 (Part 3 §4.1).
+- MUST: 컴파일 타임에 아키텍처 위반을 원천 차단한다. ArchUnit은 보조 수단일 뿐, 1차 방어선이 될 수 없다.
 
 ---
 

--- a/.claude/rules/scaffold.md
+++ b/.claude/rules/scaffold.md
@@ -239,6 +239,40 @@ public final class {Subject} {
 }
 ```
 
+### 내부 Entity 템플릿 (Credential 패턴)
+
+Aggregate 내부의 하위 Entity. 외부에서 직접 접근 금지, package-private `create()`/`reconstitute()`.
+
+```java
+// {Subject} Aggregate 내부 Entity — 외부에서 직접 접근 금지
+public final class {ChildEntity} {
+    private final {ChildEntity}Id id;
+    private final {ChildEntity}Type type;
+    private final Instant createdAt;
+
+    private {ChildEntity}({ChildEntity}Id id, {ChildEntity}Type type, Instant createdAt) {
+        this.id = Objects.requireNonNull(id);
+        this.type = Objects.requireNonNull(type);
+        this.createdAt = Objects.requireNonNull(createdAt);
+    }
+
+    // package-private — Aggregate Root를 통해서만 생성
+    static {ChildEntity} create({ChildEntity}Type type, Instant now) {
+        return new {ChildEntity}({ChildEntity}Id.generate(), type, now);
+    }
+
+    static {ChildEntity} reconstitute({ChildEntity}Id id, {ChildEntity}Type type, Instant createdAt) {
+        return new {ChildEntity}(id, type, createdAt);
+    }
+
+    public {ChildEntity}Id id() { return id; }
+    public {ChildEntity}Type type() { return type; }
+}
+```
+
+- MUST: 내부 Entity의 `create()`, `reconstitute()`는 package-private. Aggregate Root를 통해서만 생성.
+- MUST: 외부에서 내부 Entity를 직접 생성하는 것을 금지한다.
+
 ### PersistenceAdapter 템플릿 (AD-3, AD-7)
 
 ```java
@@ -308,6 +342,83 @@ class {Context}BeanConfiguration {
 ```
 
 > **Anchor Comment**: 새 UseCase Bean 추가 시 `// --- AI_ANCHOR: ADD_NEW_USECASE_BEANS_HERE ---` 바로 **아래에** 삽입한다. 기존 코드를 건드리지 않는다.
+
+### EventTranslator 템플릿 (Domain → Integration)
+
+Configuration 모듈에서 Domain Event를 Integration Event로 변환한다.
+
+```java
+// {bc}-configuration 모듈
+@Component
+class {Bc}EventTranslator {
+    private final ApplicationEventPublisher publisher;
+
+    {Bc}EventTranslator(ApplicationEventPublisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @TransactionalEventListener
+    void on({Subject}CreatedEvent event) {
+        publisher.publishEvent(new {Subject}CreatedIntegrationEvent(
+            event.aggregateId(),
+            event.occurredAt()
+        ));
+    }
+    // --- AI_ANCHOR: ADD_NEW_EVENT_TRANSLATION_HERE ---
+}
+```
+
+- MUST: EventTranslator는 Configuration 모듈에 위치한다.
+- MUST: `@TransactionalEventListener`로 Domain Event를 수신하고 Integration Event로 재발행한다.
+
+### BC 내 Aggregate 간 이벤트 기반 분리 템플릿
+
+같은 BC 내 Aggregate 간 통신은 Domain Event를 직접 사용한다 (Integration Event 불필요).
+
+```java
+// {bc}-adapter-input-event — 같은 BC 내 Aggregate 간
+@Component
+class {Subject}EventHandler {
+    private final {Verb}{Target}UseCase useCase;
+
+    @ApplicationModuleListener
+    void on({Subject}{Action}Event event) {
+        useCase.execute(new {Verb}{Target}Command(
+            event.aggregateId().toString()
+        ));
+    }
+}
+```
+
+- MUST: 1 TX = 1 Aggregate. 복수 Aggregate 변경이 필요하면 이벤트 기반으로 분리한다.
+- MUST: 이벤트 핸들러는 `adapter-input-event` 모듈에 위치한다.
+
+### Cross-BC Integration Event 수신 패턴 (adapter-input-event)
+
+다른 BC에서 발행한 Integration Event를 수신하는 핸들러 템플릿.
+
+```java
+// {bc}-adapter-input-event 모듈
+@Component
+class {Source}{Subject}EventHandler {
+    private final {Verb}{Target}UseCase useCase;
+
+    {Source}{Subject}EventHandler({Verb}{Target}UseCase useCase) {
+        this.useCase = useCase;
+    }
+
+    @ApplicationModuleListener
+    void on({Subject}{Action}IntegrationEvent event) {
+        useCase.execute(new {Verb}{Target}Command(
+            event.userId().toString(),
+            event.occurredAt().toString()
+        ));
+    }
+}
+```
+
+- MUST: BC 간 통신은 `@ApplicationModuleListener`로 Integration Event(shared-event 모듈)를 수신한다.
+- MUST: 핸들러는 UseCase를 통해 비즈니스 처리한다. 핸들러에서 직접 Port를 호출하지 않는다.
 
 ### BeanRegistrar 대안 (UseCase 10개 이상)
 
@@ -539,6 +650,26 @@ Create{Subject}Service.java
 [Phase 5: DDL]
 V{n}__create_{subject}.sql
 ```
+
+---
+
+## 신규 프로젝트 생성 9단계 템플릿
+
+**입력**: `{project}` (프로젝트명), `{context}` (첫 번째 BC), `{base-package}` (루트 패키지)
+
+| Step | 내용 | 참조 |
+|------|------|------|
+| 1 | `settings.gradle.kts` 생성 — module() 함수, 5개 BC 모듈 등록 | modulith.md §2 |
+| 2 | 루트 `build.gradle.kts` + `libs.versions.toml` 생성 | modulith.md §5 |
+| 3 | `{context}` BC 5개 모듈 디렉토리 트리 생성 | 위 §신규 BC 모듈 초기화 체크리스트 Step 1 |
+| 4 | 각 모듈 `build.gradle.kts` 생성 (label + dependencies) | 위 §신규 BC 모듈 초기화 체크리스트 Step 2 |
+| 5 | `{context}-domain`에 DomainEvent 인터페이스 생성 | 위 §Domain Event 템플릿 |
+| 6 | `shared-event` 모듈 생성 — Integration Event record | modulith.md §6 |
+| 7 | `boot-api` 모듈 생성 — `@Modulithic`, `application.yml` | modulith.md §2 |
+| 8 | Docker Compose 생성 (PostgreSQL + Grafana LGTM) | — |
+| 9 | Flyway 초기 DDL + `event_publication` 테이블 | 위 §DDL 템플릿 |
+
+- MUST: Step 1~9 순서를 지킨다. `./gradlew build`로 검증 후 첫 번째 Aggregate + UseCase 생성.
 
 ---
 

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -81,6 +81,19 @@ public void execute(UpdateProfileCommand cmd) {
 }
 ```
 
+### 2단계 인가 판단 (Resource Server)
+
+IDP가 아닌 다른 BC(또는 외부 서비스)가 Resource Server로 동작할 때 2단계 인가를 수행한다.
+
+```
+1단계 (Scope):     "이 앱의 토큰에 write scope가 있는가?" → Filter/Interceptor (Adapter)
+2단계 (Permission): "이 사용자가 user:create 권한이 있는가?" → Application 계층 (AuthorizationPolicy)
+```
+
+- MUST: 1단계 Scope 검사는 Adapter(Filter/Interceptor)에서 수행한다.
+- MUST: 2단계 Permission 검사는 Application 계층에서 AuthorizationPolicy Output Port를 통해 수행한다.
+- MUST NOT: Controller에서 직접 Permission 검사를 수행한다.
+
 ---
 
 ## 3. 계층별 RequestContext 접근 규칙
@@ -283,10 +296,46 @@ OAuthScope: String name + Set<Permission>
 
 ### 토큰 비대화 방지 (Permission이 수백 개인 경우)
 
+엔터프라이즈 환경에서 Permission이 수백 개에 달하면 JWT HTTP Header Size Limit(8KB)을 초과할 수 있다.
+
+| 방안 | JWT 내용 | Permission 조회 | 적합한 상황 |
+|------|---------|----------------|-----------|
+| **A. Introspection** (기본) | scope만 | Resource Server가 `/introspect` 또는 Redis 캐시 | Permission 수가 많고, 실시간 권한 변경 필요 |
+| **B. Opaque Token** | 토큰 자체에 정보 없음 | 매 요청마다 IDP에 조회 | 보안 최우선, 토큰 탈취 위험 최소화 |
+| **C. Permission이 적은 경우** | scope + permissions 둘 다 | 불필요 | Permission 수십 개 이하, 단순한 서비스 |
+
+- MUST: 본 프로젝트는 방안 A(Introspection)를 기본으로 한다.
+- MAY: 보안 최우선 환경에서는 방안 B(Opaque Token)를 선택할 수 있다.
+
+### 외부 Resource Server 권한 갱신 전략
+
+외부 Resource Server는 다른 JVM이므로 Spring Modulith 이벤트가 닿지 않는다.
+
+**기본: 짧은 Access Token TTL + Refresh 순환**
+
 ```
-기본: JWT에는 OAuth2 Scope만 포함 (거친 수준)
-세밀한 Permission은 /introspect 엔드포인트 또는 Redis 캐시에서 조회
+Access Token TTL: 5~15분
+Refresh Token: 장기 유효
+
+1. Resource Server가 Access Token 검증 → 만료됨
+2. Client가 Refresh Token으로 새 Access Token 요청
+3. IDP가 그 시점의 최신 Permission으로 새 토큰 발급
+→ 최대 지연 = Access Token TTL
 ```
+
+**긴급: Token Revocation (강제 로그아웃, 권한 박탈)**
+
+- IDP가 해당 토큰을 Revocation List에 등록 → Resource Server가 /introspect 확인 → 즉시 차단.
+
+**프로젝트 성장 단계별 전략**
+
+| 단계 | 인프라 | 내부 BC 간 | 외부 Resource Server |
+|------|--------|----------|-------------------|
+| **초기** | Spring Modulith만 | Modulith 이벤트 (in-process) | 짧은 TTL + Revocation |
+| **성장기** | + Redis | Modulith 이벤트 + Redis pub/sub | Redis 캐시 + 이벤트 무효화 |
+| **확장기** | + Kafka | Modulith Externalization → Kafka | Kafka 구독 또는 OpenID CAEP |
+
+- SHOULD: 초기에는 짧은 Access Token TTL + Revocation으로 시작한다. 코드 변경 없이 인프라만 교체된다.
 
 ---
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -486,6 +486,75 @@ class ArchitectureTest {
 
 ---
 
+## 10.1. Configuration 테스트
+
+TX 프록시와 EventTranslator가 올바르게 동작하는지 검증.
+
+### TX 프록시 검증
+
+```java
+@SpringBootTest
+@Testcontainers
+class TxProxyIntegrationTest {
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:17");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("spring.datasource.url", postgres::getJdbcUrl);
+    }
+
+    @Autowired private RegisterUserUseCase registerUseCase;
+    @Autowired private DSLContext dsl;
+
+    @Test
+    void UseCase_실행이_트랜잭션_내에서_완료() {
+        var command = new RegisterUserCommand("TX테스트", "tx@test.com", "pw");
+        registerUseCase.execute(command);
+        var count = dsl.selectCount().from("users")
+            .where(field("email").eq("tx@test.com")).fetchOne(0, int.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void UseCase_실패_시_롤백() {
+        var cmd1 = new RegisterUserCommand("A", "rollback@test.com", "pw");
+        registerUseCase.execute(cmd1);
+        assertThatThrownBy(() -> registerUseCase.execute(
+            new RegisterUserCommand("B", "rollback@test.com", "pw")));
+        var count = dsl.selectCount().from("users")
+            .where(field("email").eq("rollback@test.com")).fetchOne(0, int.class);
+        assertThat(count).isEqualTo(1);
+    }
+}
+```
+
+### EventTranslator 검증
+
+```java
+@SpringBootTest
+@Testcontainers
+class EventTranslatorTest {
+    @Autowired private RegisterUserUseCase registerUseCase;
+    @Autowired private DSLContext dsl;
+
+    @Test
+    void DomainEvent에서_IntegrationEvent로_변환() {
+        registerUseCase.execute(new RegisterUserCommand("이벤트", "evt@test.com", "pw"));
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            var publications = dsl.selectFrom("event_publication")
+                .where(field("event_type").like("%UserRegisteredIntegrationEvent%"))
+                .fetch();
+            assertThat(publications).isNotEmpty();
+        });
+    }
+}
+```
+
+- MUST: Configuration 테스트는 `{bc}-configuration` 모듈의 `src/test/java`에 위치한다.
+
+---
+
 ## 11. 모듈별 테스트 파일 위치
 
 | 모듈 | 테스트 파일 | 도구 |
@@ -548,6 +617,18 @@ class ArchitectureTest {
 
 **Modulith — MUST**
 - [ ] `ApplicationModules.of().verify()` 검증
+
+**Configuration — SHOULD**
+- [ ] TX 프록시: UseCase 실행이 트랜잭션 내에서 완료 (커밋 후 DB 데이터 존재)
+- [ ] TX 프록시: UseCase 실패 시 롤백 검증
+- [ ] EventTranslator: DomainEvent → IntegrationEvent 변환 검증 (event_publication 테이블)
+
+**Modulith — MUST 보강**
+- [ ] `@ApplicationModuleTest(STANDALONE)` 모듈 단독 기동 검증
+- [ ] `PublishedEvents`로 Integration Event 발행 검증
+
+**Domain Property-Based — SHOULD**
+- [ ] jqwik `@Property` 테스트로 VO 경계값 검증 (유효/무효 입력)
 
 ---
 

--- a/.claude/rules/validation.md
+++ b/.claude/rules/validation.md
@@ -11,9 +11,9 @@ alwaysApply: true
 
 | Tier | 강제 수단 | 실패 시 대응 | 대상 규칙 |
 |------|----------|-------------|----------|
-| **Tier 1** | CI 자동 (ArchUnit, 금지 import 검사) | 빌드 실패 — 즉시 수정 | D-1~D-4, A-1, A-4, AD-1~AD-2 |
-| **Tier 2** | AI 자기검증 (PR 체크리스트) | AI가 자동 수정 후 재커밋 | D-5~D-14, A-2~A-3, A-5~A-11, AD-3~AD-7, T-1~T-3 |
-| **Tier 3** | 코드 리뷰 (사람) | 리뷰어 지적 시 수정 | 네이밍 규칙(D-12, 모듈명), Aggregate 크기·경계 설계, 전략적 설계 판단 |
+| **Tier 1** | CI 자동 (ArchUnit, Gradle 의존성 검사) | 빌드 실패 — 즉시 수정 | D-1, D-2, D-3, A-1, A-4, AD-1, AD-2 |
+| **Tier 2** | AI 자기검증 (import 스캔, 패턴 매칭) | AI가 자동 수정 후 재커밋 | D-4, D-6, D-8, D-13, D-14, A-2, A-3, A-6, A-7, A-9, A-10, AD-3, AD-5, AD-7, T-1~T-3 |
+| **Tier 3** | 코드 리뷰 (사람) | 리뷰어 지적 시 수정 | D-5, D-9, D-11, D-12, A-5, A-8, AD-4, AD-6 |
 
 - MUST: Tier 1 위반은 커밋 전에 반드시 해결한다.
 - MUST: Tier 2 위반은 AI가 자기검증 체크리스트로 확인 후 자동 수정한다.
@@ -143,8 +143,13 @@ MUST NOT (Domain 직접 참조 금지):
 - MUST NOT: Controller에서 TX 시작 (T-2)
 - MUST NOT: Port 구현체 내부에서 독립 TX 시작 (T-3)
 
+### Configuration 모듈
+- MUST: Bean 와이어링, TX 프록시, EventTranslator, 공유 인프라 Bean만 수행한다.
+- MUST NOT: Configuration 모듈에 if/else 비즈니스 판단, 도메인 로직, 데이터 변환 로직을 작성한다 (Part 3 §4.3).
+
 ### 추적성
 - MUST NOT: Domain Event 페이로드에 `traceId` 포함 — OpenTelemetry가 메시지 헤더로 전파 (A-11)
+- MUST NOT: Domain Event 페이로드에 `userId`(요청자), `tenantId` 포함 — 요청 컨텍스트는 Adapter가 메시지 헤더로 주입 (Part 12 §5.4)
 - MUST: 비즈니스 컨텍스트(userId, tenantId, permissions) 전파에 `ScopedValue` (Java 25) 사용
 - MUST NOT: `ThreadLocal` 사용 — Virtual Thread 환경 위험
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ docs/specs/
 
 # Git worktrees
 .worktrees/
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/specs/
 
 # Git worktrees
 .worktrees/
+.worktrees/

--- a/docs/decisions/0016-ecs-log-format.md
+++ b/docs/decisions/0016-ecs-log-format.md
@@ -1,0 +1,38 @@
+# ADR-0016: ECS JSON 구조화 로깅 채택
+
+## Status
+
+Accepted
+
+## Context
+
+서비스 관측성(observability) 확보를 위해 로그, 트레이스, 메트릭 세 신호를 traceId로 상관(correlate)해야 한다.
+로그 형식이 비구조적(plain text)이면 파싱 비용이 높고, traceId 자동 주입이 불가능하다.
+
+Spring Boot 4는 `logging.structured.format.console: ecs` 설정으로 ECS(Elastic Common Schema) JSON 형식을 네이티브 지원한다.
+
+선택지:
+- **ECS JSON** (채택): Spring Boot 4 네이티브 지원, OpenTelemetry traceId/spanId 자동 MDC 주입, Kibana/Grafana Loki 직접 파싱 가능.
+- **Logstash JSON**: 별도 Logback 의존성 필요, ECS 표준 미준수.
+- **Plain Text**: 파싱 오버헤드, 반구조화된 패턴 유지보수 비용.
+
+## Decision
+
+Spring Boot 4의 ECS JSON 구조화 로깅을 채택한다.
+
+설정:
+```yaml
+logging:
+  structured:
+    format:
+      console: ecs
+```
+
+OpenTelemetry MDC 자동 주입으로 모든 로그에 `traceId`, `spanId` 포함. 별도 코드 불필요.
+
+## Consequences
+
+- ✅ traceId/spanId 자동 주입 → 로그-트레이스-메트릭 상관 분석 가능
+- ✅ ECS 표준 준수 → Kibana, Grafana Loki 직접 연동
+- ✅ Spring Boot 4 네이티브 지원 → 추가 의존성 없음
+- ⚠️ 개발 환경 가독성 감소 → `application-dev.yml`에서 plain text 오버라이드 허용

--- a/docs/decisions/0017-jib-container-build.md
+++ b/docs/decisions/0017-jib-container-build.md
@@ -1,0 +1,50 @@
+# ADR-0017: Jib 컨테이너 이미지 빌드 도구 채택
+
+## Status
+
+Accepted
+
+## Context
+
+컨테이너 이미지 빌드 방법:
+- **Dockerfile**: Docker 데몬 필요, 레이어 캐시 수동 관리, 빌드 환경 의존.
+- **Buildpacks**: Cloud Native Buildpacks, 설정 제어 제한적.
+- **Jib** (채택): Docker 데몬 불필요, Gradle/Maven 플러그인, 레이어 자동 최적화, OCI 표준 이미지 생성.
+
+CI/CD 환경에서 Docker 데몬 없이 이미지를 빌드해야 하며, 레이어 캐시 최적화로 빌드 시간을 줄여야 한다.
+
+Jib은 의존성, 리소스, 클래스 파일을 별도 레이어로 분리하여 변경된 레이어만 재빌드한다.
+
+## Decision
+
+Google Jib Gradle 플러그인을 채택한다.
+
+```kotlin
+// boilerplate-boot-api/build.gradle.kts
+jib {
+    from { image = "eclipse-temurin:25-jre" }
+    to {
+        image = "ghcr.io/ppzxc/boilerplate"
+        tags = setOf("latest", project.version.toString())
+    }
+    container {
+        jvmFlags = listOf(
+            "-XX:+UseZGC",
+            "-XX:+ZGenerational",
+            "-XX:MaxRAMPercentage=75.0",
+            "-Djava.security.egd=file:/dev/urandom"
+        )
+        ports = listOf("8080")
+    }
+}
+```
+
+기반 이미지: `eclipse-temurin:25-jre` (JRE only, 최소 크기).
+JVM 플래그: ZGC (Java 25 권장 GC), MaxRAMPercentage 75%.
+
+## Consequences
+
+- ✅ Docker 데몬 불필요 → CI/CD 환경 단순화
+- ✅ 레이어 자동 최적화 → 의존성 변경 없으면 클래스 레이어만 재빌드
+- ✅ GHCR(GitHub Container Registry) 직접 푸시 가능
+- ⚠️ Dockerfile 기반 커스터마이징 불가 → 일반적 Spring Boot 앱에는 문제 없음

--- a/docs/decisions/0018-github-actions-cicd.md
+++ b/docs/decisions/0018-github-actions-cicd.md
@@ -1,0 +1,35 @@
+# ADR-0018: GitHub Actions CI/CD 파이프라인 채택
+
+## Status
+
+Accepted
+
+## Context
+
+CI/CD 플랫폼 선택지:
+- **Jenkins**: 자체 호스팅, 플러그인 관리 오버헤드, 인프라 비용.
+- **GitLab CI**: GitLab 종속성.
+- **GitHub Actions** (채택): 코드와 동일 플랫폼, 무료 공개 리포지토리, Marketplace 생태계, OIDC 기반 권한 관리.
+
+이 프로젝트는 GitHub에서 호스팅되므로 GitHub Actions가 최적이다.
+
+CI 필수 게이트: 컴파일, 테스트, 커버리지, 코드 품질, 정적 분석, Modulith 구조 검증, 보안 스캔(7개).
+
+## Decision
+
+GitHub Actions를 CI/CD 플랫폼으로 채택한다.
+
+- CI 워크플로우: `.github/workflows/ci.yml` — PR/push 트리거, 5단계 게이트
+- CD 워크플로우: `.github/workflows/cd.yml` — main push 시 Jib 이미지 빌드/푸시
+- Release 워크플로우: `.github/workflows/release.yml` — `v*` 태그 트리거, GitHub Release 자동 생성
+
+Gradle `--no-daemon` 필수 (메모리 누수 방지).
+NVD API Key를 GitHub Secrets에 등록 (OWASP 스캔 속도 향상).
+
+## Consequences
+
+- ✅ 코드와 CI 설정이 동일 리포지토리 → 코드 리뷰 시 CI 변경도 검토 가능
+- ✅ OIDC 기반 클라우드 연동 → 장기 크리덴셜 불필요
+- ✅ GitHub Marketplace 풍부한 Actions 생태계
+- ⚠️ GitHub 종속성 → 대안 이전 시 워크플로우 재작성 필요
+- ⚠️ 월별 무료 사용량 한도 (공개 리포: 무제한, 비공개: 2,000분/월)

--- a/docs/decisions/0019-bc-based-authorization-placement.md
+++ b/docs/decisions/0019-bc-based-authorization-placement.md
@@ -1,0 +1,39 @@
+# ADR-0019: BC 기반 인가 배치 원칙
+
+## Status
+
+Accepted
+
+## Context
+
+인가(Authorization) 로직을 어느 계층, 어느 BC에 배치할지 결정해야 한다.
+
+선택지:
+1. **모든 BC의 Domain 계층**: Domain 순수성(D-1) 위반. Spring/ScopedValue import 금지 원칙 충돌.
+2. **모든 BC의 Application 계층**: Identity BC조차도 Application에서만 인가 처리 → Identity의 Rich Domain Model 약화.
+3. **BC 성격에 따른 분리** (채택):
+   - Identity BC: Domain 계층 (User, Role, Permission이 비즈니스 도메인 그 자체)
+   - 다른 BC: Application 계층 (인가 정책 소비만, AuthorizationPolicy Output Port 경유)
+
+Controller에서 직접 Permission 검사 금지 — 계층 경계 위반 + 테스트 불가.
+
+## Decision
+
+인가 처리 위치는 BC의 성격에 따라 결정한다.
+
+| BC | 인가 위치 | 이유 |
+|----|----------|------|
+| Identity BC | Domain 계층 | Permission이 비즈니스 도메인 자체 |
+| 다른 BC | Application 계층 | 인가 정책 소비자, Domain 순수성 유지 |
+
+2단계 인가:
+- 1단계 (Scope): Adapter(Filter)에서 OAuth2 Scope 검사
+- 2단계 (Permission): Application에서 AuthorizationPolicy Output Port를 통해 세밀한 Permission 검사
+
+## Consequences
+
+- ✅ Identity BC의 Rich Domain Model 보존 (Permission, Role, User 비즈니스 불변식 Domain 내 캡슐화)
+- ✅ 다른 BC의 Domain 순수성 유지 (Spring/ScopedValue import 없음)
+- ✅ AuthorizationPolicy Output Port → 테스트 시 Mock 교체 가능
+- ✅ 2단계 인가로 Scope(앱 수준) + Permission(사용자 수준) 분리
+- ⚠️ BC마다 다른 인가 배치 위치 → 팀 규칙 이해 필요

--- a/docs/decisions/0020-access-token-ttl-refresh-strategy.md
+++ b/docs/decisions/0020-access-token-ttl-refresh-strategy.md
@@ -1,0 +1,38 @@
+# ADR-0020: Access Token TTL + Refresh Token 전략
+
+## Status
+
+Accepted
+
+## Context
+
+IDP(Identity Provider)가 발급한 JWT Access Token을 Resource Server가 검증할 때, 권한 변경이 즉시 반영되어야 하는지(실시간성)와 성능(매 요청마다 IDP 조회 vs 캐시)을 균형잡아야 한다.
+
+선택지:
+- **긴 TTL (1시간+)**: 권한 변경 지연 최대 1시간, 탈취 위험 높음.
+- **짧은 TTL (5~15분) + Refresh Token** (채택): 권한 변경 최대 반영 지연 = TTL, 탈취 피해 최소화.
+- **Opaque Token + Introspection**: 실시간 권한 반영, 매 요청마다 IDP 네트워크 호출.
+
+Modulith 단계에서는 in-process 이벤트로 내부 BC 간 권한 동기화가 가능하지만, 외부 Resource Server는 다른 JVM이므로 Spring Modulith 이벤트가 닿지 않는다.
+
+## Decision
+
+짧은 Access Token TTL(5~15분) + Refresh Token 순환 전략을 기본으로 채택한다.
+
+- Access Token TTL: 5~15분 (운영 환경별 조정)
+- Refresh Token: 장기 유효, DB 저장, 회전(rotation) 방식
+- 긴급 차단: Token Revocation → IDP Revocation List + /introspect 연동
+
+단계별 확장 전략:
+1. 초기: 짧은 TTL + Revocation (코드 변경 없음)
+2. 성장기: Redis Pub/Sub으로 권한 변경 이벤트 무효화
+3. 확장기: Kafka + OpenID CAEP 표준 이벤트
+
+## Consequences
+
+- ✅ 권한 변경 최대 지연 = Access Token TTL (5~15분) — 비즈니스 수용 가능
+- ✅ 탈취된 Access Token의 유효 기간 최소화
+- ✅ Resource Server가 매 요청 IDP 호출 불필요 → 성능 유지
+- ✅ Refresh Token 회전으로 재사용 탐지 가능
+- ⚠️ 권한 즉시 박탈이 필요한 경우 → Revocation 엔드포인트 필수 구현
+- ⚠️ Refresh Token 저장소(DB) 관리 필요

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -35,6 +35,16 @@
 | [0014](0014-no-framework-annotations-in-domain.md) | Domain에 프레임워크 어노테이션 금지 | D-2 | Accepted |
 | [0015](0015-no-logging-framework-in-domain.md) | Domain에 로깅 프레임워크 금지 | D-3 | Accepted |
 
+### 인프라 & 보안 결정 (0016-0020)
+
+| ADR | 제목 | 관련 규칙 | 상태 |
+|-----|------|----------|------|
+| [0016](0016-ecs-log-format.md) | ECS JSON 구조화 로깅 채택 | observability.md §3 | Accepted |
+| [0017](0017-jib-container-build.md) | Jib 컨테이너 이미지 빌드 도구 채택 | cicd.md §6 | Accepted |
+| [0018](0018-github-actions-cicd.md) | GitHub Actions CI/CD 파이프라인 채택 | cicd.md §7 | Accepted |
+| [0019](0019-bc-based-authorization-placement.md) | BC 기반 인가 배치 원칙 | security.md §1-2 | Accepted |
+| [0020](0020-access-token-ttl-refresh-strategy.md) | Access Token TTL + Refresh Token 전략 | security.md §9 | Accepted |
+
 ## ADR 작성 가이드
 
 새 ADR은 다음 규칙을 따른다:


### PR DESCRIPTION
## Summary

- `docs/playbook/purist-ddd-playbook` 대비 `.claude/rules/*` + `docs/decisions/*` 누락 내용 전체 반영
- 8개 rules 파일 수정 + 5개 ADR 신규 생성 (ADR-0016 ~ 0020)

## 변경 파일 (14개, +839 lines)

### Rules 수정 (8개)

| 파일 | 변경 내용 |
|------|---------|
| `validation.md` | Tier 매핑 수정, Configuration 모듈 규칙 추가, 이벤트 페이로드 금지 규칙 추가 |
| `modulith.md` | 단일 모듈 구조 금지 MUST, 컴파일 타임 아키텍처 위반 차단 원칙 추가 |
| `cqrs.md` | §8.1 동시성 제어 원칙 (Optimistic/Pessimistic/CAS 비교표) 추가 |
| `security.md` | 2단계 인가 판단, 토큰 비대화 방지 3방안 비교표, 외부 Resource Server 권한 갱신 전략 추가 |
| `scaffold.md` | 내부 Entity 템플릿, EventTranslator 템플릿, BC 내 Aggregate 간 이벤트 분리, Cross-BC 수신 패턴, 신규 프로젝트 9단계 템플릿 추가 |
| `testing.md` | §10.1 Configuration 테스트(TX 프록시 + EventTranslator 검증), AI 체크리스트 확장 추가 |
| `harness.md` | test-support 모듈(DomainTestBase/Testcontainers Singleton/Fixture Factory), Lefthook, PIT Mutation Testing, OpenRewrite 추가 |
| `cicd.md` | §6 Jib 빌드, §7 GitHub Actions CI 파이프라인, §8 릴리스 관리(SemVer/Git 태깅/Release 워크플로우) 추가 |

### ADR 신규 (5개)

| ADR | 제목 |
|-----|------|
| ADR-0016 | ECS JSON 구조화 로깅 채택 |
| ADR-0017 | Jib 컨테이너 이미지 빌드 도구 채택 |
| ADR-0018 | GitHub Actions CI/CD 파이프라인 채택 |
| ADR-0019 | BC 기반 인가 배치 원칙 |
| ADR-0020 | Access Token TTL + Refresh Token 전략 |

## Test Plan

- [ ] `.claude/rules/*.md` 파일 내용이 playbook과 일치하는지 확인
- [ ] `docs/decisions/index.md` 인덱스가 0016-0020 ADR을 올바르게 참조하는지 확인
- [ ] rules 파일 간 상호 참조(ADR 번호)가 정확한지 확인
- [ ] 기존 §1~§5 (cicd.md) 내용이 손상되지 않았는지 확인