### PR TITLE
docs(rules): P1 보강 — ADR 참조 3건 + anti-pattern 5종 + playbook 금지

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,3 +56,7 @@
 - 중요한 결정 발생 시 → ADR 먼저 작성 후 구현
 - 기존 rules의 MUST/MUST NOT 임의 변경 금지 → ADR 작성 후 사람 승인 필요
 - 규칙 충돌 시 → 해당 ADR 파일 직접 읽어 결정 배경 파악 후 대안 제안
+
+### 금지 경로
+
+- **MUST NOT**: `docs/playbook/` 디렉토리의 파일을 읽거나 참조한다. playbook 내용은 `.claude/rules/`와 `docs/decisions/`로 완전히 이관되었다. 모든 규칙과 템플릿은 rules 파일만을 정본으로 사용한다.

--- a/.claude/rules/domain.md
+++ b/.claude/rules/domain.md
@@ -565,6 +565,11 @@ public final class AuditLog {
 | **Direct Aggregate Reference** | 다른 Aggregate 객체를 필드로 보유. | ID(VO)만 참조. 객체 참조 금지. [D-9] |
 | **Direct EventPublisher Call** | Application Service에서 EventPublisher 직접 호출. | SavePort 구현체(Adapter)가 pullDomainEvents() 후 발행. [AD-3] |
 | **Leaky Abstraction** | Domain Entity에 `@Entity`, `@Table` 등 기술 어노테이션 침투. | 순수 Java만. 기술 매핑은 Adapter Mapper에서 수동 수행. [D-1, D-2] |
+| **Primitive Obsession** | 도메인 의미가 있는 값을 `String`, `Long` 등 원시 타입으로 직접 사용. | record VO로 래핑. `UserId(UUID)`, `Email(String)` 등. [D-7] |
+| **Service Orchestration Overload** | Application Service에 if/else 비즈니스 판단이 집중. Domain이 빈 껍데기. | 비즈니스 판단을 Domain Entity/VO의 행위 메서드로 위임. [A-5] |
+| **Cross-Aggregate Transaction** | 하나의 UseCase에서 복수 Aggregate를 동일 TX로 변경. | 이벤트 기반으로 분리. 1 TX = 1 Aggregate. [A-9] |
+| **Event Amnesia** | SavePort 구현체에서 `pullDomainEvents()` 호출 누락. 이벤트 소실. | `save()` 내부에서 반드시 수거 후 `ApplicationEventPublisher.publishEvent()`. [AD-3] |
+| **Shotgun Parsing** | 입력 검증이 Controller, Service, Domain에 분산. 어디서 실패할지 불명확. | 검증 책임 분리: Command self-validation → VO Compact Constructor → Entity 불변식 순서 엄수. |
 
 ---
 

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -316,5 +316,5 @@ return ObservedProxy.create(txProxy, "identity.user.register", registry);
 
 ---
 > 위 규칙을 현재 상황에 적용하기 어렵거나 규칙 간 충돌이 발생하면,
-> `docs/decisions/ADR-0012-*.md` 파일을 직접 읽어
+> `docs/decisions/ADR-0012-*.md`(ScopedValue 컨텍스트 전파) 또는 `ADR-0016-*.md`(ECS 구조화 로깅 채택 근거) 파일을 직접 읽어
 > 결정의 배경을 파악한 후 최적의 대안을 제안하라.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -400,5 +400,6 @@ public record UserDeactivatedEvent(
 
 ---
 > 위 규칙을 현재 상황에 적용하기 어렵거나 규칙 간 충돌이 발생하면,
-> `docs/decisions/ADR-0013-*.md` 파일을 직접 읽어
+> `docs/decisions/ADR-0013-*.md`(Permission 패턴), `ADR-0019-*.md`(BC 기반 인가 배치 원칙),
+> `ADR-0020-*.md`(Access Token TTL + Refresh 전략) 파일을 직접 읽어
 > 결정의 배경을 파악한 후 최적의 대안을 제안하라.


### PR DESCRIPTION
## Summary
- `observability.md` fallback에 ADR-0016(ECS 구조화 로깅) 참조 추가
- `security.md` fallback에 ADR-0019(BC 기반 인가), ADR-0020(토큰 TTL) 참조 추가
- `domain.md` anti-pattern 표에 누락 5종 보강 (Primitive Obsession, Service Orchestration Overload, Cross-Aggregate Transaction, Event Amnesia, Shotgun Parsing)
- `CLAUDE.md`에 `docs/playbook/` 읽기 금지 지시 추가 — rules/ADR만 정본으로 사용

## Context
playbook → rules/ADR 마이그레이션 최종 점검 결과 발견된 P1 갭 3건 수정.
전체 마이그레이션 평가: 35개 규칙 전수 반영, ADR 20/20 참조 완료, 모순 0건.

## Test plan
- [ ] rules 파일 내 ADR 참조 번호가 실제 `docs/decisions/` 파일과 일치하는지 확인
- [ ] domain.md anti-pattern 표에 중복 항목 없는지 확인
- [ ] CLAUDE.md 금지 경로 지시가 명확한지 확인