### PR TITLE
build(deps): bump org.checkerframework:checker-qual from 3.53.0 to 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ configureByLabel("java") {
   configurations.all {
     resolutionStrategy {
       force("com.google.errorprone:error_prone_annotations:2.49.0")
-      force("org.checkerframework:checker-qual:3.53.0")
+      force("org.checkerframework:checker-qual:4.0.0")
       eachDependency {
         if (requested.group == "org.junit.platform" && requested.name == "junit-platform-launcher") {
           useVersion("6.0.3")


### PR DESCRIPTION
## Summary

- `org.checkerframework:checker-qual` 버전을 `3.53.0` → `4.0.0`으로 업그레이드
- Dependabot PR #91을 대체 (PR #91은 기반 버전 충돌로 직접 병합 불가)
- NullAway 0.13.2 + ErrorProne 2.49.0 환경에서 빌드 호환성 검증 완료

## Dependabot PR #91 대체 이유

PR #91 생성 시점(3.48.4)과 현재 main(3.53.0)의 기반 버전이 달라 머지 충돌 발생.
실제 업그레이드 효과(3.x → 4.0.0)는 동일하며, 직접 빌드 테스트로 호환성 확인.

## Test plan

- [x] `:boilerplate-domain:compileJava` — BUILD SUCCESSFUL
- [x] `:boilerplate-application:compileJava` — BUILD SUCCESSFUL
- [x] `:boilerplate-boot-api:compileJava` — BUILD SUCCESSFUL

Closes #91

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.