### PR TITLE
build(harness): lefthook 전면 정비 — parallel/skip/fail_text/commit-msg/Modulith

### DIFF
--- a/.claude/rules/harness.md
+++ b/.claude/rules/harness.md
@@ -286,6 +286,7 @@ pre-commit:
       glob: "*.java"
       run: ./gradlew checkstyleMain
       skip: [merge, rebase]
+      fail_text: "❌ Checkstyle 위반. build/reports/checkstyle/main.html 확인."
 
 commit-msg:
   jobs:

--- a/.claude/rules/harness.md
+++ b/.claude/rules/harness.md
@@ -258,6 +258,7 @@ public abstract class AdapterTestBase {
 ## 8. Lefthook (로컬 Git Hooks)
 
 Lefthook은 Git hooks 관리자. CI 전 로컬에서 품질 검사를 실행하여 위반 코드 커밋/푸시 차단.
+Lefthook의 목적은 "빠른 로컬 차단". CI(`cicd.md §1`)가 동일 검사를 다시 수행함.
 
 ```kotlin
 // build.gradle.kts
@@ -266,26 +267,51 @@ plugins {
 }
 ```
 
+**주요 구성 패턴 (실제 `lefthook.yml` 기준)**:
+
 ```yaml
-# lefthook.yml
+# lefthook.yml — 핵심 패턴
+min_version: 1.7.0
+assert_lefthook_installed: true
+
 pre-commit:
+  parallel: true                      # job 동시 실행
   jobs:
     - name: spotless-check
-      run: ./gradlew spotlessCheck
+      glob: "*.{java,kt,kts}"
+      run: ./gradlew spotlessCheck    # --no-daemon 불필요 (로컬은 daemon ON)
+      skip: [merge, rebase]
+      fail_text: "❌ 자동 수정: ./gradlew spotlessApply"
     - name: checkstyle
       glob: "*.java"
       run: ./gradlew checkstyleMain
+      skip: [merge, rebase]
+
+commit-msg:
+  jobs:
+    - name: conventional-commits
+      run: |
+        head -1 "{1}" | grep -qE \
+          '^(feat|fix|refactor|perf|chore|build|ci|docs|test|style|revert)(\(.+\))?!?: .+$' \
+          || { printf '❌ Conventional Commits 형식 위반\n예: feat(identity): JWT 로그인 구현\n'; exit 1; }
+      skip: [merge, rebase]
 
 pre-push:
+  parallel: true
   jobs:
     - name: unit-tests
-      run: ./gradlew test -x :*:adapter-*:test -x :*:configuration:test
-    - name: archunit
-      run: ./gradlew test --tests "*ArchitectureTest*"
+      run: ./gradlew test -x :boilerplate-boot:test
+      skip: [merge, rebase]
+    - name: arch-and-modulith
+      run: ./gradlew :boilerplate-boot:test --tests "*ArchitectureTest*" --tests "*ModulithStructureTest*"
+      skip: [merge, rebase]
 ```
 
+**핵심 원칙**:
 - SHOULD: `lefthook.yml`은 리포지토리에 버전 관리. 팀 전원 동일 hooks. 로컬 오버라이드는 `lefthook-local.yml`(gitignore).
 - MUST: `./gradlew lefthookInstall`로 Git hooks 자동 설치.
+- MUST: 모든 job에 `skip: [merge, rebase]` 적용하여 머지/리베이스 중 hook 발동 방지.
+- MUST NOT: `--no-daemon`을 로컬 hook에 적용한다. CI에만 적용 (§2 참조).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker compose up -d
 개인 hook 추가/비활성화(팀 공유 안 됨):
 ```bash
 # lefthook-local.yml 생성 (이미 .gitignore에 포함)
-echo "pre-commit:\n  skip: true" > lefthook-local.yml
+printf 'pre-commit:\n  skip: true\n' > lefthook-local.yml
 ```
 
 ### Hook 우회 (비권장)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,36 @@ docker compose up -d
 |--------|------|
 | `NVD_API_KEY` | OWASP Dependency-Check NVD API (없으면 스캔 느림) |
 
+## Development Setup (로컬 개발 환경)
+
+### Git Hooks (Lefthook)
+
+`./gradlew build` 실행 시 Lefthook 훅이 자동 설치됨. 이후 커밋/푸시 시 자동 검사 실행.
+
+수동 설치:
+```bash
+./gradlew lefthookInstall
+```
+
+개인 hook 추가/비활성화(팀 공유 안 됨):
+```bash
+# lefthook-local.yml 생성 (이미 .gitignore에 포함)
+echo "pre-commit:\n  skip: true" > lefthook-local.yml
+```
+
+### Hook 우회 (비권장)
+
+```bash
+# pre-commit/commit-msg 건너뜀 — 긴급 상황에만 사용
+git commit --no-verify -m "..."
+# pre-push 건너뜀
+git push --no-verify
+```
+
+> ⚠️ `--no-verify`는 품질 검사를 무력화함. CI에서 재차 차단.
+
+---
+
 ## 개발 규칙
 
 - **규칙 정본**: `.claude/rules/*.md` (15개 파일)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,57 @@
+# Lefthook 2.x — 로컬 1차 방어선 (방어선 0)
+# 공식 문서: https://lefthook.dev/configuration/
+# CI는 이 검사들을 다시 실행함 — Lefthook의 목적은 "빠른 로컬 차단"
+min_version: 1.7.0
+assert_lefthook_installed: true
+
 pre-commit:
+  parallel: true
   jobs:
     - name: spotless-check
-      run: ./gradlew spotlessCheck --no-daemon
+      glob: "*.{java,kt,kts}"
+      run: ./gradlew spotlessCheck
+      skip:
+        - merge
+        - rebase
+      fail_text: |
+        ❌ Spotless 포맷 위반. 자동 수정: ./gradlew spotlessApply
+
     - name: checkstyle
       glob: "*.java"
-      run: ./gradlew checkstyleMain --no-daemon
+      run: ./gradlew checkstyleMain
+      skip:
+        - merge
+        - rebase
+      fail_text: |
+        ❌ Checkstyle 위반. build/reports/checkstyle/main.html 확인.
+
+commit-msg:
+  jobs:
+    - name: conventional-commits
+      run: |
+        head -1 "{1}" | grep -qE \
+          '^(feat|fix|refactor|perf|chore|build|ci|docs|test|style|revert)(\(.+\))?!?: .+$' \
+          || { printf '❌ Conventional Commits 형식 위반\n예: feat(identity): JWT 로그인 구현\n허용 타입: feat|fix|refactor|perf|chore|build|ci|docs|test|style|revert\n'; exit 1; }
+      skip:
+        - merge
+        - rebase
 
 pre-push:
+  parallel: true
   jobs:
     - name: unit-tests
-      run: ./gradlew test -x :boilerplate-boot:test --no-daemon
-    - name: archunit
-      run: ./gradlew :boilerplate-boot:test --tests "*ArchitectureTest*" --no-daemon
+      run: ./gradlew test -x :boilerplate-boot:test
+      skip:
+        - merge
+        - rebase
+      fail_text: |
+        ❌ 단위 테스트 실패. 푸시 전 수정 필요.
+
+    - name: arch-and-modulith
+      run: ./gradlew :boilerplate-boot:test --tests "*ArchitectureTest*" --tests "*ModulithStructureTest*"
+      skip:
+        - merge
+        - rebase
+      fail_text: |
+        ❌ ArchUnit / Modulith 구조 검증 실패.
+        의존 방향·금지 패턴·모듈 경계 점검 필요.


### PR DESCRIPTION
## Summary

- `parallel: true` 추가 (pre-commit·pre-push) — job 동시 실행으로 대기 시간 단축
- `--no-daemon` 전 job 제거 — 로컬 Gradle daemon ON이 공식 권장 (CI에만 적용)
- `skip: [merge, rebase]` 전 job 적용 — 머지/리베이스 중 hook 발동 방지
- `fail_text` 추가 — 실패 시 수정 방법을 즉시 안내
- `min_version: 1.7.0`, `assert_lefthook_installed: true` 추가
- `commit-msg` hook 신규 — bash 정규식 기반 Conventional Commits 검증 (외부 의존성 0)
- `arch-and-modulith` job으로 확장 — `ModulithStructureTest` 포함 (`harness.md §3` MUST 정합)
- `harness.md §8` 예시를 실제 `lefthook.yml`과 동기화
- `README` Development Setup에 lefthook 설치·우회 안내 추가

## 채택하지 않은 변경 (의도적)

| 항목 | 보류 사유 |
|---|---|
| `{staged_files}` | Gradle task는 파일 인자 방식 미지원 — 별도 ADR 필요 |
| `stage_fixed: true` + `spotlessApply` | 자동 수정 정책 미결정 |
| gitleaks | 외부 바이너리 설치 부담 (사용자 결정으로 철회) |
| actionlint | 외부 바이너리 설치 부담, 변경 빈도 낮음 (사용자 결정으로 철회) |

## Test plan

- [ ] `lefthook validate` 통과 확인
- [ ] `git commit` 시 spotless-check·checkstyle·conventional-commits hook 실행 확인
- [ ] Conventional Commits 위반 메시지 → commit-msg hook 차단 확인
- [ ] `git commit --no-verify` 시 hook 건너뜀 확인
- [ ] `git merge` / `git rebase` 중 hook skip 확인
- [ ] `git push` 시 unit-tests·arch-and-modulith 병렬 실행 확인

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.